### PR TITLE
DBZ-2975: Extract offset context from object states to method signatures

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
@@ -12,7 +12,6 @@ import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.util.Clock;
 
 /**
@@ -20,7 +19,7 @@ import io.debezium.util.Clock;
  *
  * @author Chris Cranford
  */
-public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory {
+public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory<MongoDbOffsetContext> {
 
     private final MongoDbConnectorConfig configuration;
     private final ErrorHandler errorHandler;
@@ -40,12 +39,11 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
     }
 
     @Override
-    public SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<MongoDbOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
         return new MongoDbSnapshotChangeEventSource(
                 configuration,
                 taskContext,
                 replicaSets,
-                (MongoDbOffsetContext) offsetContext,
                 dispatcher,
                 clock,
                 snapshotProgressListener,
@@ -53,12 +51,11 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
     }
 
     @Override
-    public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
+    public StreamingChangeEventSource<MongoDbOffsetContext> getStreamingChangeEventSource() {
         return new MongoDbStreamingChangeEventSource(
                 configuration,
                 taskContext,
                 replicaSets,
-                (MongoDbOffsetContext) offsetContext,
                 dispatcher,
                 errorHandler,
                 clock);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -44,7 +44,7 @@ import io.debezium.util.SchemaNameAdjuster;
  * @author Randall Hauch
  */
 @ThreadSafe
-public final class MongoDbConnectorTask extends BaseSourceTask {
+public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbOffsetContext> {
 
     private static final String CONTEXT_NAME = "mongodb-connector-task";
 
@@ -63,7 +63,7 @@ public final class MongoDbConnectorTask extends BaseSourceTask {
     }
 
     @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
+    public ChangeEventSourceCoordinator<MongoDbOffsetContext> start(Configuration config) {
         final MongoDbConnectorConfig connectorConfig = new MongoDbConnectorConfig(config);
         final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create(logger);
 
@@ -103,7 +103,7 @@ public final class MongoDbConnectorTask extends BaseSourceTask {
                     metadataProvider,
                     schemaNameAdjuster);
 
-            ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
+            ChangeEventSourceCoordinator<MongoDbOffsetContext> coordinator = new ChangeEventSourceCoordinator<>(
                     previousOffsets,
                     errorHandler,
                     MongoDbConnector.class,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
@@ -17,11 +17,10 @@ import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
 
-public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory {
+public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<MySqlOffsetContext> {
 
     private final MySqlConnectorConfig configuration;
     private final MySqlConnection connection;
@@ -51,8 +50,8 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory {
     }
 
     @Override
-    public SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener) {
-        return new MySqlSnapshotChangeEventSource(configuration, (MySqlOffsetContext) offsetContext, connection, taskContext.getSchema(), dispatcher, clock,
+    public SnapshotChangeEventSource<MySqlOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+        return new MySqlSnapshotChangeEventSource(configuration, connection, taskContext.getSchema(), dispatcher, clock,
                 (MySqlSnapshotChangeEventSourceMetrics) snapshotProgressListener, record -> modifyAndFlushLastRecord(record));
     }
 
@@ -62,11 +61,10 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory {
     }
 
     @Override
-    public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
+    public StreamingChangeEventSource<MySqlOffsetContext> getStreamingChangeEventSource() {
         queue.disableBuffering();
         return new MySqlStreamingChangeEventSource(
                 configuration,
-                (MySqlOffsetContext) offsetContext,
                 connection,
                 dispatcher,
                 errorHandler,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -40,7 +40,7 @@ import io.debezium.util.SchemaNameAdjuster;
  * @author Jiri Pechanec
  *
  */
-public class MySqlConnectorTask extends BaseSourceTask {
+public class MySqlConnectorTask extends BaseSourceTask<MySqlOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MySqlConnectorTask.class);
     private static final String CONTEXT_NAME = "mysql-connector-task";
@@ -57,7 +57,7 @@ public class MySqlConnectorTask extends BaseSourceTask {
     }
 
     @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
+    public ChangeEventSourceCoordinator<MySqlOffsetContext> start(Configuration config) {
         final Clock clock = Clock.system();
         final MySqlConnectorConfig connectorConfig = new MySqlConnectorConfig(config);
         final TopicSelector<TableId> topicSelector = MySqlTopicSelector.defaultSelector(connectorConfig);
@@ -123,7 +123,7 @@ public class MySqlConnectorTask extends BaseSourceTask {
 
         final MySqlStreamingChangeEventSourceMetrics streamingMetrics = new MySqlStreamingChangeEventSourceMetrics(taskContext, queue, metadataProvider);
 
-        ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
+        ChangeEventSourceCoordinator<MySqlOffsetContext> coordinator = new ChangeEventSourceCoordinator<>(
                 previousOffset,
                 errorHandler,
                 MySqlConnector.class,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -38,7 +38,6 @@ import io.debezium.connector.mysql.legacy.MySqlJdbcContext.DatabaseLocales;
 import io.debezium.data.Envelope;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.pipeline.EventDispatcher;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.Column;
 import io.debezium.relational.RelationalSnapshotChangeEventSource;
 import io.debezium.relational.RelationalTableFilters;
@@ -50,7 +49,7 @@ import io.debezium.util.Clock;
 import io.debezium.util.Collect;
 import io.debezium.util.Strings;
 
-public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource {
+public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<MySqlOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MySqlSnapshotChangeEventSource.class);
 
@@ -60,28 +59,26 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
     private long tableLockAcquiredAt = -1;
     private final RelationalTableFilters filters;
     private final MySqlSnapshotChangeEventSourceMetrics metrics;
-    private final MySqlOffsetContext previousOffset;
     private final MySqlDatabaseSchema databaseSchema;
     private final List<SchemaChangeEvent> schemaEvents = new ArrayList<>();
     private Set<TableId> delayedSchemaSnapshotTables = Collections.emptySet();
     private final BlockingConsumer<Function<SourceRecord, SourceRecord>> lastEventProcessor;
 
-    public MySqlSnapshotChangeEventSource(MySqlConnectorConfig connectorConfig, MySqlOffsetContext previousOffset, MySqlConnection connection,
+    public MySqlSnapshotChangeEventSource(MySqlConnectorConfig connectorConfig, MySqlConnection connection,
                                           MySqlDatabaseSchema schema, EventDispatcher<TableId> dispatcher, Clock clock,
                                           MySqlSnapshotChangeEventSourceMetrics metrics,
                                           BlockingConsumer<Function<SourceRecord, SourceRecord>> lastEventProcessor) {
-        super(connectorConfig, previousOffset, connection, schema, dispatcher, clock, metrics);
+        super(connectorConfig, connection, schema, dispatcher, clock, metrics);
         this.connectorConfig = connectorConfig;
         this.connection = connection;
         this.filters = connectorConfig.getTableFilters();
         this.metrics = metrics;
-        this.previousOffset = previousOffset;
         this.databaseSchema = schema;
         this.lastEventProcessor = lastEventProcessor;
     }
 
     @Override
-    protected SnapshottingTask getSnapshottingTask(OffsetContext previousOffset) {
+    protected SnapshottingTask getSnapshottingTask(MySqlOffsetContext previousOffset) {
         boolean snapshotSchema = true;
         boolean snapshotData = true;
 
@@ -260,7 +257,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
     }
 
     @Override
-    protected void determineSnapshotOffset(RelationalSnapshotContext ctx) throws Exception {
+    protected void determineSnapshotOffset(RelationalSnapshotContext ctx, MySqlOffsetContext previousOffset) throws Exception {
         if (!isGloballyLocked() && !isTablesLocked() && connectorConfig.getSnapshotLockingMode().usesLocking()) {
             return;
         }
@@ -303,12 +300,14 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
     }
 
     @Override
-    protected void readTableStructure(ChangeEventSourceContext sourceContext, RelationalSnapshotContext snapshotContext) throws Exception {
+    protected void readTableStructure(ChangeEventSourceContext sourceContext, RelationalSnapshotContext snapshotContext,
+                                      MySqlOffsetContext offsetContext)
+            throws Exception {
         Set<TableId> capturedSchemaTables;
         if (twoPhaseSchemaSnapshot()) {
             // Capture schema of captured tables after they are locked
             tableLock(snapshotContext);
-            determineSnapshotOffset(snapshotContext);
+            determineSnapshotOffset(snapshotContext, offsetContext);
             capturedSchemaTables = snapshotContext.capturedTables;
             LOGGER.info("Table level locking is in place, the schema will be capture in two phases, now capturing: {}", capturedSchemaTables);
             delayedSchemaSnapshotTables = Collect.minus(snapshotContext.capturedSchemaTables, snapshotContext.capturedTables);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlConnectorTask.java
@@ -31,6 +31,7 @@ import io.debezium.connector.mysql.Module;
 import io.debezium.connector.mysql.MySqlConnector;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.connector.mysql.MySqlOffsetContext;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.schema.TopicSelector;
 import io.debezium.util.Collect;
@@ -44,7 +45,7 @@ import io.debezium.util.LoggingContext.PreviousContext;
  * @author Randall Hauch
  */
 @NotThreadSafe
-public final class MySqlConnectorTask extends BaseSourceTask {
+public final class MySqlConnectorTask extends BaseSourceTask<MySqlOffsetContext> {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private volatile MySqlTaskContext taskContext;
@@ -66,7 +67,7 @@ public final class MySqlConnectorTask extends BaseSourceTask {
     }
 
     @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
+    public ChangeEventSourceCoordinator<MySqlOffsetContext> start(Configuration config) {
         final String serverName = config.getString(MySqlConnectorConfig.SERVER_NAME);
         PreviousContext prevLoggingContext = LoggingContext.forConnector(Module.contextName(), serverName, "task");
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
@@ -16,11 +16,10 @@ import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
 
-public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactory {
+public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactory<PostgresOffsetContext> {
 
     private final PostgresConnectorConfig configuration;
     private final PostgresConnection jdbcConnection;
@@ -52,11 +51,10 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     }
 
     @Override
-    public SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<PostgresOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
         return new PostgresSnapshotChangeEventSource(
                 configuration,
                 snapshotter,
-                (PostgresOffsetContext) offsetContext,
                 jdbcConnection,
                 schema,
                 dispatcher,
@@ -67,11 +65,10 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     }
 
     @Override
-    public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
+    public StreamingChangeEventSource<PostgresOffsetContext> getStreamingChangeEventSource() {
         return new PostgresStreamingChangeEventSource(
                 configuration,
                 snapshotter,
-                (PostgresOffsetContext) offsetContext,
                 jdbcConnection,
                 dispatcher,
                 errorHandler,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -48,7 +48,7 @@ import io.debezium.util.SchemaNameAdjuster;
  *
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
-public class PostgresConnectorTask extends BaseSourceTask {
+public class PostgresConnectorTask extends BaseSourceTask<PostgresOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresConnectorTask.class);
     private static final String CONTEXT_NAME = "postgres-connector-task";
@@ -60,7 +60,7 @@ public class PostgresConnectorTask extends BaseSourceTask {
     private volatile PostgresSchema schema;
 
     @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
+    public ChangeEventSourceCoordinator<PostgresOffsetContext> start(Configuration config) {
         final PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
         final TopicSelector<TableId> topicSelector = PostgresTopicSelector.create(connectorConfig);
         final Snapshotter snapshotter = connectorConfig.getSnapshotter();

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -11,11 +11,10 @@ import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
 
-public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFactory {
+public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFactory<SqlServerOffsetContext> {
 
     private final SqlServerConnectorConfig configuration;
     private final SqlServerConnection dataConnection;
@@ -37,16 +36,15 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
     }
 
     @Override
-    public SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener) {
-        return new SqlServerSnapshotChangeEventSource(configuration, (SqlServerOffsetContext) offsetContext, dataConnection, schema, dispatcher, clock,
+    public SnapshotChangeEventSource<SqlServerOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+        return new SqlServerSnapshotChangeEventSource(configuration, dataConnection, schema, dispatcher, clock,
                 snapshotProgressListener);
     }
 
     @Override
-    public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
+    public StreamingChangeEventSource<SqlServerOffsetContext> getStreamingChangeEventSource() {
         return new SqlServerStreamingChangeEventSource(
                 configuration,
-                (SqlServerOffsetContext) offsetContext,
                 dataConnection,
                 metadataConnection,
                 dispatcher,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -23,7 +23,6 @@ import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.DatabaseHistory;
@@ -38,7 +37,7 @@ import io.debezium.util.SchemaNameAdjuster;
  * @author Jiri Pechanec
  *
  */
-public class SqlServerConnectorTask extends BaseSourceTask {
+public class SqlServerConnectorTask extends BaseSourceTask<SqlServerOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerConnectorTask.class);
     private static final String CONTEXT_NAME = "sql-server-connector-task";
@@ -56,7 +55,7 @@ public class SqlServerConnectorTask extends BaseSourceTask {
     }
 
     @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
+    public ChangeEventSourceCoordinator<SqlServerOffsetContext> start(Configuration config) {
         final Clock clock = Clock.system();
         final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(config);
         final TopicSelector<TableId> topicSelector = SqlServerTopicSelector.defaultSelector(connectorConfig);
@@ -84,7 +83,7 @@ public class SqlServerConnectorTask extends BaseSourceTask {
         this.schema = new SqlServerDatabaseSchema(connectorConfig, valueConverters, topicSelector, schemaNameAdjuster);
         this.schema.initializeStorage();
 
-        final OffsetContext previousOffset = getPreviousOffset(new SqlServerOffsetContext.Loader(connectorConfig));
+        final SqlServerOffsetContext previousOffset = (SqlServerOffsetContext) getPreviousOffset(new SqlServerOffsetContext.Loader(connectorConfig));
         if (previousOffset != null) {
             schema.recover(previousOffset);
         }
@@ -114,7 +113,7 @@ public class SqlServerConnectorTask extends BaseSourceTask {
                 metadataProvider,
                 schemaNameAdjuster);
 
-        ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
+        ChangeEventSourceCoordinator<SqlServerOffsetContext> coordinator = new ChangeEventSourceCoordinator<>(
                 previousOffset,
                 errorHandler,
                 SqlServerConnector.class,

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -39,7 +39,7 @@ import io.debezium.util.Strings;
  *
  * @author Gunnar Morling
  */
-public abstract class BaseSourceTask extends SourceTask {
+public abstract class BaseSourceTask<O extends OffsetContext> extends SourceTask {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseSourceTask.class);
     private static final long INITIAL_POLL_PERIOD_IN_MILLIS = TimeUnit.SECONDS.toMillis(5);
@@ -68,7 +68,7 @@ public abstract class BaseSourceTask extends SourceTask {
      * The change event source coordinator for those connectors adhering to the new
      * framework structure, {@code null} for legacy-style connectors.
      */
-    private ChangeEventSourceCoordinator coordinator;
+    private ChangeEventSourceCoordinator<O> coordinator;
 
     /**
      * The latest offset that has been acknowledged by the Kafka producer. Will be
@@ -141,7 +141,7 @@ public abstract class BaseSourceTask extends SourceTask {
      *            the task configuration; implementations should wrap it in a dedicated implementation of
      *            {@link CommonConnectorConfig} and work with typed access to configuration properties that way
      */
-    protected abstract ChangeEventSourceCoordinator start(Configuration config);
+    protected abstract ChangeEventSourceCoordinator<O> start(Configuration config);
 
     @Override
     public final List<SourceRecord> poll() throws InterruptedException {

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -40,7 +40,7 @@ import io.debezium.util.Threads;
  * @author Gunnar Morling
  */
 @ThreadSafe
-public class ChangeEventSourceCoordinator {
+public class ChangeEventSourceCoordinator<O extends OffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ChangeEventSourceCoordinator.class);
 
@@ -49,24 +49,24 @@ public class ChangeEventSourceCoordinator {
      */
     public static final Duration SHUTDOWN_WAIT_TIMEOUT = Duration.ofSeconds(90);
 
-    private final OffsetContext previousOffset;
+    private final O previousOffset;
     private final ErrorHandler errorHandler;
-    private final ChangeEventSourceFactory changeEventSourceFactory;
+    private final ChangeEventSourceFactory<O> changeEventSourceFactory;
     private final ChangeEventSourceMetricsFactory changeEventSourceMetricsFactory;
     private final ExecutorService executor;
     private final EventDispatcher<?> eventDispatcher;
     private final DatabaseSchema<?> schema;
 
     private volatile boolean running;
-    private volatile StreamingChangeEventSource streamingSource;
+    private volatile StreamingChangeEventSource<O> streamingSource;
     private final ReentrantLock commitOffsetLock = new ReentrantLock();
 
     private SnapshotChangeEventSourceMetrics snapshotMetrics;
     private StreamingChangeEventSourceMetrics streamingMetrics;
 
-    public ChangeEventSourceCoordinator(OffsetContext previousOffset, ErrorHandler errorHandler, Class<? extends SourceConnector> connectorType,
+    public ChangeEventSourceCoordinator(O previousOffset, ErrorHandler errorHandler, Class<? extends SourceConnector> connectorType,
                                         CommonConnectorConfig connectorConfig,
-                                        ChangeEventSourceFactory changeEventSourceFactory,
+                                        ChangeEventSourceFactory<O> changeEventSourceFactory,
                                         ChangeEventSourceMetricsFactory changeEventSourceMetricsFactory, EventDispatcher<?> eventDispatcher, DatabaseSchema<?> schema) {
         this.previousOffset = previousOffset;
         this.errorHandler = errorHandler;
@@ -93,7 +93,7 @@ public class ChangeEventSourceCoordinator {
                 ChangeEventSourceContext context = new ChangeEventSourceContextImpl();
                 LOGGER.info("Context created");
 
-                SnapshotChangeEventSource snapshotSource = changeEventSourceFactory.getSnapshotChangeEventSource(previousOffset, snapshotMetrics);
+                SnapshotChangeEventSource<O> snapshotSource = changeEventSourceFactory.getSnapshotChangeEventSource(snapshotMetrics);
                 CatchUpStreamingResult catchUpStreamingResult = executeCatchUpStreaming(previousOffset, context, snapshotSource);
                 if (catchUpStreamingResult.performedCatchUpStreaming) {
                     streamingConnected(false);
@@ -102,7 +102,7 @@ public class ChangeEventSourceCoordinator {
                     commitOffsetLock.unlock();
                 }
                 eventDispatcher.setEventListener(snapshotMetrics);
-                SnapshotResult snapshotResult = snapshotSource.execute(context);
+                SnapshotResult<O> snapshotResult = snapshotSource.execute(context, previousOffset);
                 LOGGER.info("Snapshot ended with {}", snapshotResult);
 
                 if (snapshotResult.getStatus() == SnapshotResultStatus.COMPLETED || schema.tableInformationComplete()) {
@@ -127,17 +127,17 @@ public class ChangeEventSourceCoordinator {
     }
 
     protected CatchUpStreamingResult executeCatchUpStreaming(OffsetContext previousOffset, ChangeEventSourceContext context,
-                                                             SnapshotChangeEventSource snapshotSource)
+                                                             SnapshotChangeEventSource<O> snapshotSource)
             throws InterruptedException {
         return new CatchUpStreamingResult(false);
     }
 
-    protected void streamEvents(OffsetContext offsetContext, ChangeEventSourceContext context) throws InterruptedException {
-        streamingSource = changeEventSourceFactory.getStreamingChangeEventSource(offsetContext);
+    protected void streamEvents(O offsetContext, ChangeEventSourceContext context) throws InterruptedException {
+        streamingSource = changeEventSourceFactory.getStreamingChangeEventSource();
         eventDispatcher.setEventListener(streamingMetrics);
         streamingConnected(true);
         LOGGER.info("Starting streaming");
-        streamingSource.execute(context);
+        streamingSource.execute(context, offsetContext);
         LOGGER.info("Finished streaming");
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
@@ -12,26 +12,24 @@ import io.debezium.pipeline.spi.OffsetContext;
  *
  * @author Gunnar Morling
  */
-public interface ChangeEventSourceFactory {
+public interface ChangeEventSourceFactory<O extends OffsetContext> {
 
     /**
      * Returns a snapshot change event source that may emit change events for schema and/or data changes. Depending on
      * the snapshot mode, a given source may decide to do nothing at all if a previous offset is given. In this case it
      * should return that given offset context from its
-     * {@link StreamingChangeEventSource#execute(io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext)}
+     * {@link StreamingChangeEventSource#execute(ChangeEventSource.ChangeEventSourceContext, io.debezium.pipeline.spi.OffsetContext)}
      * method.
      *
-     * @param offsetContext
-     *            A context representing a restored offset from an earlier run of this connector. May be {@code null}.
      * @param snapshotProgressListener
      *            A listener called for changes in the state of snapshot. May be {@code null}.
      *
      * @return A snapshot change event source
      */
-    SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener);
+    SnapshotChangeEventSource<O> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener);
 
     /**
      * Returns a streaming change event source that starts streaming at the given offset.
      */
-    StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext);
+    StreamingChangeEventSource<O> getStreamingChangeEventSource();
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotChangeEventSource.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.pipeline.source.spi;
 
+import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.SnapshotResult;
 
 /**
@@ -13,7 +14,7 @@ import io.debezium.pipeline.spi.SnapshotResult;
  *
  * @author Gunnar Morling
  */
-public interface SnapshotChangeEventSource extends ChangeEventSource {
+public interface SnapshotChangeEventSource<O extends OffsetContext> extends ChangeEventSource {
 
     /**
      * Executes this source. Implementations should regularly check via the given context if they should stop. If that's
@@ -22,9 +23,10 @@ public interface SnapshotChangeEventSource extends ChangeEventSource {
      *
      * @param context
      *            contextual information for this source's execution
+     * @param previousOffset
      * @return an indicator to the position at which the snapshot was taken
      * @throws InterruptedException
      *             in case the snapshot was aborted before completion
      */
-    SnapshotResult execute(ChangeEventSourceContext context) throws InterruptedException;
+    SnapshotResult<O> execute(ChangeEventSourceContext context, O previousOffset) throws InterruptedException;
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
@@ -7,12 +7,14 @@ package io.debezium.pipeline.source.spi;
 
 import java.util.Map;
 
+import io.debezium.pipeline.spi.OffsetContext;
+
 /**
  * A change event source that emits events from a DB log, such as MySQL's binlog or similar.
  *
  * @author Gunnar Morling
  */
-public interface StreamingChangeEventSource extends ChangeEventSource {
+public interface StreamingChangeEventSource<O extends OffsetContext> extends ChangeEventSource {
 
     /**
      * Executes this source. Implementations should regularly check via the given context if they should stop. If that's
@@ -21,11 +23,12 @@ public interface StreamingChangeEventSource extends ChangeEventSource {
      *
      * @param context
      *            contextual information for this source's execution
+     * @param offsetContext
      * @return an indicator to the position at which the snapshot was taken
      * @throws InterruptedException
      *             in case the snapshot was aborted before completion
      */
-    void execute(ChangeEventSourceContext context) throws InterruptedException;
+    void execute(ChangeEventSourceContext context, O offsetContext) throws InterruptedException;
 
     /**
      * Commits the given offset with the source database. Used by some connectors

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/SnapshotResult.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/SnapshotResult.java
@@ -5,26 +5,26 @@
  */
 package io.debezium.pipeline.spi;
 
-public class SnapshotResult {
+public class SnapshotResult<O extends OffsetContext> {
 
     private final SnapshotResultStatus status;
-    private final OffsetContext offset;
+    private final O offset;
 
-    private SnapshotResult(SnapshotResultStatus status, OffsetContext offset) {
+    private SnapshotResult(SnapshotResultStatus status, O offset) {
         this.status = status;
         this.offset = offset;
     }
 
-    public static SnapshotResult completed(OffsetContext offset) {
-        return new SnapshotResult(SnapshotResultStatus.COMPLETED, offset);
+    public static <O extends OffsetContext> SnapshotResult<O> completed(O offset) {
+        return new SnapshotResult<>(SnapshotResultStatus.COMPLETED, offset);
     }
 
-    public static SnapshotResult aborted() {
-        return new SnapshotResult(SnapshotResultStatus.ABORTED, null);
+    public static <O extends OffsetContext> SnapshotResult<O> aborted() {
+        return new SnapshotResult<>(SnapshotResultStatus.ABORTED, null);
     }
 
-    public static SnapshotResult skipped(OffsetContext offset) {
-        return new SnapshotResult(SnapshotResultStatus.SKIPPED, offset);
+    public static <O extends OffsetContext> SnapshotResult<O> skipped(O offset) {
+        return new SnapshotResult<>(SnapshotResultStatus.SKIPPED, offset);
     }
 
     public boolean isCompletedOrSkipped() {
@@ -35,7 +35,7 @@ public class SnapshotResult {
         return status;
     }
 
-    public OffsetContext getOffset() {
+    public O getOffset() {
         return offset;
     }
 


### PR DESCRIPTION
Closes #8.

It should be possible to reuse the graph of components under `ChangeEventSourceCoordinator` for processing multiple partitions represented via `OffsetContext` sequentially. Specifically, `StreamingChangeEventSource#execute()` and `SnapshotChangeEventSource#execute()` should accept an offset context and explicitly pass it down the line.

The following classes and hierarchies no longer have the offset context as part of their state which is now part of their interface:
1. `ChangeEventSourceFactory` (including all connector implementations).
2. `SnapshotChangeEventSource` (including snapshot/streaming interfaces and all connector implementations).
3. Connector-specific classes (`mysql.EventBuffer`).

Certain classes are parametrized with `<O extends OffsetContext`>. Since the graph of components under the `SourceTask` implementation will be dealing with a set of contexts, there may be no place to do typecasting for the entire set. Additionally, the use of parameterized types looks safer:
1. `BaseSourceTask`
2. `ChangeEventSourceCoordinator`
3. `ChangeEventSourceFactory`
4. `SnapshotChangeEventSource`
5. `SnapshotResult`