### PR TITLE
DBZ-2975: Prototype multiple offset contexts per task

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlOffsetContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlOffsetContext.java
@@ -181,7 +181,7 @@ public class MySqlOffsetContext implements OffsetContext {
         return offset;
     }
 
-    public static class Loader implements OffsetContext.Loader {
+    public static class Loader implements OffsetContext.Loader<MySqlOffsetContext> {
 
         private final MySqlConnectorConfig connectorConfig;
 
@@ -195,7 +195,7 @@ public class MySqlOffsetContext implements OffsetContext {
         }
 
         @Override
-        public OffsetContext load(Map<String, ?> offset) {
+        public MySqlOffsetContext load(Map<String, ?> offset) {
             boolean snapshot = Boolean.TRUE.equals(offset.get(SourceInfo.SNAPSHOT_KEY)) || "true".equals(offset.get(SourceInfo.SNAPSHOT_KEY));
             boolean snapshotCompleted = Boolean.TRUE.equals(offset.get(SNAPSHOT_COMPLETED_KEY)) || "true".equals(offset.get(SNAPSHOT_COMPLETED_KEY));
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -183,7 +183,7 @@ public class PostgresOffsetContext implements OffsetContext {
         return sourceInfo.xmin();
     }
 
-    public static class Loader implements OffsetContext.Loader {
+    public static class Loader implements OffsetContext.Loader<PostgresOffsetContext> {
 
         private final PostgresConnectorConfig connectorConfig;
 
@@ -203,7 +203,7 @@ public class PostgresOffsetContext implements OffsetContext {
 
         @SuppressWarnings("unchecked")
         @Override
-        public OffsetContext load(Map<String, ?> offset) {
+        public PostgresOffsetContext load(Map<String, ?> offset) {
             final Lsn lsn = Lsn.valueOf(readOptionalLong(offset, SourceInfo.LSN_KEY));
             final Lsn lastCompletelyProcessedLsn = Lsn.valueOf(readOptionalLong(offset, LAST_COMPLETELY_PROCESSED_LSN_KEY));
             final Lsn lastCommitLsn = Lsn.valueOf(readOptionalLong(offset, LAST_COMPLETELY_PROCESSED_LSN_KEY));

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
@@ -22,6 +22,7 @@ import io.debezium.util.Collect;
 public class SqlServerOffsetContext implements OffsetContext {
 
     private static final String SERVER_PARTITION_KEY = "server";
+    private static final String DATABASE_PARTITION_KEY = "database";
     private static final String SNAPSHOT_COMPLETED_KEY = "snapshot_completed";
 
     private final Schema sourceInfoSchema;
@@ -37,7 +38,12 @@ public class SqlServerOffsetContext implements OffsetContext {
 
     public SqlServerOffsetContext(SqlServerConnectorConfig connectorConfig, TxLogPosition position, boolean snapshot, boolean snapshotCompleted, long eventSerialNo,
                                   TransactionContext transactionContext) {
-        partition = Collections.singletonMap(SERVER_PARTITION_KEY, connectorConfig.getLogicalName());
+        // Now this effectively duplicates {@link io.debezium.connector.common.TaskPartition},
+        // probably worth moving out of from the offset context
+        partition = Collect.hashMapOf(
+                SERVER_PARTITION_KEY, connectorConfig.getLogicalName(),
+                // TODO: this should be passed explicitly as an argument
+                DATABASE_PARTITION_KEY, connectorConfig.getDatabaseName());
         sourceInfo = new SourceInfo(connectorConfig);
 
         sourceInfo.setCommitLsn(position.getCommitLsn());
@@ -136,7 +142,7 @@ public class SqlServerOffsetContext implements OffsetContext {
         sourceInfo.setSnapshot(SnapshotRecord.FALSE);
     }
 
-    public static class Loader implements OffsetContext.Loader {
+    public static class Loader implements OffsetContext.Loader<SqlServerOffsetContext> {
 
         private final SqlServerConnectorConfig connectorConfig;
 
@@ -150,7 +156,7 @@ public class SqlServerOffsetContext implements OffsetContext {
         }
 
         @Override
-        public OffsetContext load(Map<String, ?> offset) {
+        public SqlServerOffsetContext load(Map<String, ?> offset) {
             final Lsn changeLsn = Lsn.valueOf((String) offset.get(SourceInfo.CHANGE_LSN_KEY));
             final Lsn commitLsn = Lsn.valueOf((String) offset.get(SourceInfo.COMMIT_LSN_KEY));
             boolean snapshot = Boolean.TRUE.equals(offset.get(SourceInfo.SNAPSHOT_KEY));

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerTaskPartition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerTaskPartition.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.common.TaskPartition;
+
+public class SqlServerTaskPartition implements TaskPartition {
+    private static final String SERVER_PARTITION_KEY = "server";
+    private static final String DATABASE_PARTITION_KEY = "database";
+
+    private final String serverName;
+    private final String databaseName;
+
+    public SqlServerTaskPartition(String serverName, String databaseName) {
+        this.serverName = serverName;
+        this.databaseName = databaseName;
+    }
+
+    @Override
+    public Map<String, String> getSourcePartition() {
+        Map<String, String> partition = new HashMap<>();
+        partition.put(SERVER_PARTITION_KEY, serverName);
+        partition.put(DATABASE_PARTITION_KEY, databaseName);
+
+        return partition;
+    }
+
+    String getDatabaseName() {
+        return databaseName;
+    }
+
+    static class Provider implements TaskPartition.Provider<SqlServerTaskPartition> {
+        private final SqlServerConnectorConfig connectorConfig;
+        private final Configuration taskConfig;
+
+        Provider(SqlServerConnectorConfig connectorConfig, Configuration taskConfig) {
+            this.connectorConfig = connectorConfig;
+            this.taskConfig = taskConfig;
+        }
+
+        @Override
+        public Collection<SqlServerTaskPartition> getPartitions() {
+            String serverName = connectorConfig.getLogicalName();
+
+            // TODO: source database names from the task configuration, throw if the array is empty
+            String[] databaseNames = { connectorConfig.getDatabaseName() };
+
+            return Arrays.stream(databaseNames)
+                    .map(databaseName -> new SqlServerTaskPartition(serverName, databaseName))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/connector/common/TaskOffsetContext.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/TaskOffsetContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.common;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+
+import io.debezium.pipeline.spi.OffsetContext;
+
+public class TaskOffsetContext<P extends TaskPartition, O extends OffsetContext> {
+    private final Map<P, O> offsets;
+
+    public TaskOffsetContext(Map<P, O> offsets) {
+        this.offsets = offsets;
+    }
+
+    public Map<P, O> getOffsets() {
+        return offsets;
+    }
+
+    /**
+     * Loads connector task context.
+     */
+    public static class Loader<P extends TaskPartition, O extends OffsetContext, L extends OffsetContext.Loader<O>> {
+
+        private final OffsetStorageReader offsetReader;
+        private final L offsetLoader;
+
+        public Loader(OffsetStorageReader offsetReader, L offsetLoader) {
+            this.offsetReader = offsetReader;
+            this.offsetLoader = offsetLoader;
+        }
+
+        /**
+         * Given the collection of connector-specific task partitions, returns their respective connector-specific offsets.
+         */
+        public TaskOffsetContext<P, O> load(Collection<P> taskPartitions) {
+            Collection<Map<String, String>> sourcePartitions = taskPartitions.stream()
+                    .map(TaskPartition::getSourcePartition)
+                    .collect(Collectors.toCollection(HashSet::new));
+
+            Map<Map<String, String>, Map<String, Object>> sourceOffsets = offsetReader.offsets(sourcePartitions);
+
+            Map<P, O> taskOffsets = new HashMap<>();
+            taskPartitions.forEach(taskPartition -> {
+                Map<String, String> sourcePartition = taskPartition.getSourcePartition();
+                Map<String, Object> sourceOffset = sourceOffsets.get(sourcePartition);
+                O taskOffset = null;
+                if (sourceOffset != null) {
+                    taskOffset = offsetLoader.load(sourceOffset);
+                }
+                taskOffsets.put(taskPartition, taskOffset);
+            });
+
+            return new TaskOffsetContext<>(taskOffsets);
+        }
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/connector/common/TaskPartition.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/TaskPartition.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.common;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Describes the partition of the source to be processed by the task and provides its representation
+ * as a Kafka Connect source partition.
+ */
+public interface TaskPartition {
+    Map<String, String> getSourcePartition();
+
+    /**
+     * Implementations provide task-specific partitions based on the task configuration.
+     */
+    interface Provider<P extends TaskPartition> {
+        Collection<P> getPartitions();
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
@@ -26,10 +26,10 @@ public interface OffsetContext {
     /**
      * Implementations load a connector-specific offset context based on the offset values stored in Kafka.
      */
-    interface Loader {
+    interface Loader<O extends OffsetContext> {
         Map<String, ?> getPartition();
 
-        OffsetContext load(Map<String, ?> offset);
+        O load(Map<String, ?> offset);
     }
 
     Map<String, ?> getPartition();


### PR DESCRIPTION
Closes #12. The corresponding [section](https://gist.github.com/morozov/1157990ccd7ca00ca89637da914a4c08#source-partition-awareness-at-the-task-level-15) of the design doc.

**Change summary**:
1. `OffsetContext.Loader` is parametrized with `<O extends OffsetContext>` (see https://github.com/sugarcrm/debezium/pull/13 for the reasoning).
2. All messages produced by the SQL Server connector instead of having "server=serverName" as their source partition now have "server=serverName;database=databaseName" as their source partition. This is a breaking change from the PoV of existing users. An existing connector upgraded to this version won't be able to recover from the state produced by the previous version.

**New APIs**:
1. `TaskPartition` interface. Describes the partition of the source to be processed by the task in terms of a given connector and provides its representation as a Kafka Connect source partition. For instance, an `SqlServerTaskPartition` describes a source database. Any other connector can implement this interface in its specific terms.
2. `TaskPartition.Provider` interface. Provides a collection of task-specific partitions for a given task based on its configuration. E.g. a list `SqlServerTaskPartition`s each representing a database for a SQL Server connector task.
3. `TaskOffsetContext` class. It's effectively a map of `TaskPartition` to `OffsetContext` describing the scope of work for a given task and its state. This map will be iterated over by different task components to process multiple databases.
4. `TaskOffsetContext.Loader` class. Similarly to `OffsetContext.Loader`, loads the task offset context.