### PR TITLE
DBZ-2975: Fix inconsistent test failure due NullPointerException

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
@@ -222,7 +222,16 @@ public class SqlServerOffsetContext implements OffsetContext {
 
     @Override
     public boolean eventsStreamed() {
-        return (streamingExecutionState.getStatus() == SqlServerStreamingExecutionState.StreamingResultStatus.NO_CHANGES_IN_DATABASE
-                || streamingExecutionState.getStatus() == SqlServerStreamingExecutionState.StreamingResultStatus.NO_MAXIMUM_LSN_RECORDED) == false;
+        if (streamingExecutionState == null) {
+            return false;
+        }
+
+        switch (streamingExecutionState.getStatus()) {
+            case NO_CHANGES_IN_DATABASE:
+            case NO_MAXIMUM_LSN_RECORDED:
+                return false;
+            default:
+                return true;
+        }
     }
 }


### PR DESCRIPTION
The absence of this condition leads to sporadic [test](https://github.com/sugarcrm/debezium/pull/42/checks?check_run_id=2365676888#step:4:5097) [failures](https://github.com/sugarcrm/debezium/pull/43/checks?check_run_id=2364855269#step:4:5050) caused by a `NullPointerException`:
```
 java.lang.NullPointerException
 	at io.debezium.connector.sqlserver.SqlServerOffsetContext.eventsStreamed(SqlServerOffsetContext.java:225)
 	at io.debezium.pipeline.spi.StreamingResult.eventsStreamed(StreamingResult.java:21)
 	at io.debezium.pipeline.ChangeEventSourceCoordinator.lambda$start$0(ChangeEventSourceCoordinator.java:150)
 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
 	at java.base/java.lang.Thread.run(Thread.java:834)
```
Could be reproduced for example via `SqlServerConnectorIT#shouldPropagateSourceTypeByDatatype`.