### PR TITLE
DBZ-3452: source.timestamp.mode=commit imposes a significant performance penalty

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceTimestampMode.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceTimestampMode.java
@@ -27,6 +27,14 @@ public enum SourceTimestampMode implements EnumeratedValue {
             return connection.normalize(resultSet.getTimestamp(resultSet.getMetaData().getColumnCount()));
         }
 
+        /**
+         * Returns the query for obtaining the LSN-to-TIMESTAMP query. On SQL Server
+         * 2016 and newer, the query will normalize the value to UTC. This means that
+         * the {@link SqlServerConnection#SERVER_TIMEZONE_PROP_NAME} is not necessary to be given. The
+         * returned TIMESTAMP will be adjusted by the JDBC driver using this VM's TZ (as
+         * required by the JDBC spec), and that same TZ will be applied when converting
+         * the TIMESTAMP value into an {@code Instant}.
+         */
         @Override
         protected String lsnTimestampSelectStatement(boolean supportsAtTimeZone) {
             String result = ", " + SqlServerConnection.LSN_TIMESTAMP_SELECT_STATEMENT;

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -169,7 +169,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                         final SqlServerChangeTable[] tables = tablesSlot.get();
 
                         for (int i = 0; i < tableCount; i++) {
-                            changeTables[i] = new SqlServerChangeTablePointer(tables[i], resultSets[i]);
+                            changeTables[i] = new SqlServerChangeTablePointer(tables[i], resultSets[i], connectorConfig.getSourceTimestampMode());
                             changeTables[i].next();
                         }
 
@@ -256,7 +256,10 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                             offsetContext.setChangePosition(tableWithSmallestLsn.getChangePosition(), eventCount);
                             offsetContext.event(
                                     tableWithSmallestLsn.getChangeTable().getSourceTableId(),
-                                    metadataConnection.timestampOfLsn(tableWithSmallestLsn.getChangePosition().getCommitLsn()));
+                                    connectorConfig.getSourceTimestampMode().getTimestamp(
+                                            metadataConnection,
+                                            tableWithSmallestLsn.getResultSet(),
+                                            clock));
 
                             dispatcher
                                     .dispatchDataChangeEvent(


### PR DESCRIPTION
Documented as [DBZ-3452](https://issues.redhat.com/browse/DBZ-3452).

**Future scope**:
- [ ] Compare the connector performance with the optimization above and with `source.timestamp.mode=processing`. Depending on that, see if the following remark is still relevant:
   > [...] avoid the additional cost of Debezium querying the database to extract the LSN timestamps.
- [ ] Check if `SqlServerConnection#lsnToInstantCache` is still necessary.