### PR TITLE
DBZ-3452: source.timestamp.mode=commit imposes a significant performance penalty

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceTimestampMode.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceTimestampMode.java
@@ -27,6 +27,14 @@ public enum SourceTimestampMode implements EnumeratedValue {
             return connection.normalize(resultSet.getTimestamp(resultSet.getMetaData().getColumnCount()));
         }
 
+        /**
+         * Returns the query for obtaining the LSN-to-TIMESTAMP query. On SQL Server
+         * 2016 and newer, the query will normalize the value to UTC. This means that
+         * the {@link SqlServerConnection#SERVER_TIMEZONE_PROP_NAME} is not necessary to be given. The
+         * returned TIMESTAMP will be adjusted by the JDBC driver using this VM's TZ (as
+         * required by the JDBC spec), and that same TZ will be applied when converting
+         * the TIMESTAMP value into an {@code Instant}.
+         */
         @Override
         protected String lsnTimestampSelectStatement(boolean supportsAtTimeZone) {
             String result = ", " + SqlServerConnection.LSN_TIMESTAMP_SELECT_STATEMENT;

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -189,7 +189,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                         final SqlServerChangeTable[] tables = finalTablesSlot.get();
 
                         for (int i = 0; i < tableCount; i++) {
-                            changeTables[i] = new SqlServerChangeTablePointer(tables[i], resultSets[i]);
+                            changeTables[i] = new SqlServerChangeTablePointer(tables[i], resultSets[i], connectorConfig.getSourceTimestampMode());
                             changeTables[i].next();
                         }
 
@@ -276,7 +276,10 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                             offsetContext.setChangePosition(tableWithSmallestLsn.getChangePosition(), eventCount);
                             offsetContext.event(
                                     tableWithSmallestLsn.getChangeTable().getSourceTableId(),
-                                    metadataConnection.timestampOfLsn(tableWithSmallestLsn.getChangePosition().getCommitLsn(), partition.getDatabaseName()));
+                                    connectorConfig.getSourceTimestampMode().getTimestamp(
+                                            metadataConnection,
+                                            tableWithSmallestLsn.getResultSet(),
+                                            clock));
 
                             dispatcher
                                     .dispatchDataChangeEvent(


### PR DESCRIPTION
This is a port of https://github.com/sugarcrm/debezium/pull/48 on top of the [DBZ-2975](https://issues.redhat.com/browse/DBZ-2975) changes.