### PR TITLE
CXP-1093: allow "." and "`" characters

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
@@ -137,7 +137,7 @@ public abstract class AbstractDatabaseHistory implements DatabaseHistory {
                         }
                         catch (RuntimeException parserException) {
                             final String fixedDdl = ddl.replaceAll("\\s+", " ").trim();
-                            if (!fixedDdl.matches("(?i)^\\w+ TO \\w+$")) {
+                            if (!fixedDdl.matches("(?i)^[\\w\\.`]+ TO [\\w\\.`]+$")) {
                                 throw parserException;
                             }
                             final String renameTableDdl = "RENAME TABLE " + fixedDdl;


### PR DESCRIPTION
```java
import java.util.*;
class Main {  
  public static void main(String args[]) {
    List<String> ddls = Arrays.asList(
      "a tO b", "a \nto b ",
      "\ta   TO  b\n",
      " ab \nc to d ",
      "`db_novel`.`users`\n                  TO `db_novel`.`users_updated`",
      "`db_ths`.`tasks`\n                  TO `db_ths`.`tasks_old`"
    );
    for (String ddl : ddls) {
      String fixedDdl = ddl.replaceAll("\\s+", " ").trim();
      if (!fixedDdl.matches("(?i)^[\\w\\.`]+ TO [\\w\\.`]+$")) {
        System.out.println("ERROR: " + ddl);
        continue;
      }
      System.out.println("RENAME TABLE " + fixedDdl);
    }
  } 
}
```
```sh
RENAME TABLE a tO b
RENAME TABLE a to b
RENAME TABLE a TO b
ERROR:  ab 
c to d 
RENAME TABLE `db_novel`.`users` TO `db_novel`.`users_updated`
RENAME TABLE `db_ths`.`tasks` TO `db_ths`.`tasks_old`
```