### PR TITLE
[CXP-1130] Schema name conflict between foo-case12345 and foo_case12345 tables

### DIFF
--- a/debezium-core/src/main/java/io/debezium/util/SchemaNameAdjuster.java
+++ b/debezium-core/src/main/java/io/debezium/util/SchemaNameAdjuster.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,15 +140,12 @@ public interface SchemaNameAdjuster {
      * with a valid fullname, and throws an error if the replacement conflicts with that of a different original. This method
      * replaces all invalid characters with the underscore character ('_').
      *
-     * @param logger the logger to use; may not be null     * @return the validator; never null
+     * @return the adjuster; never null
      */
     public static SchemaNameAdjuster create() {
-        return create((original, replacement, conflict) -> {
-            String msg = "The Kafka Connect schema name '" + original +
-                    "' is not a valid Avro schema name and its replacement '" + replacement +
-                    "' conflicts with another different schema '" + conflict + "'";
-            throw new ConnectException(msg);
-        });
+        return create((original, replacement, conflict) -> LOGGER.warn("The Kafka Connect schema name '" + original +
+                "' is not a valid Avro schema name and its replacement '" + replacement +
+                "' conflicts with another different schema '" + conflict + "'"));
     }
 
     /**


### PR DESCRIPTION
The approach with a NULL implementation didn't work because there is still a static API (e.g. `SchemaNameAdjuster#isValidFullname(String)`) that connectors call to validate the resulting schema name. It would have to be removed as well.

Instead, we can just replace the exception with a warning. Unlike AVRO, where the schema name is a pointer to the actual schema in the registry, with JSON serialization it's just for reference and doesn't have to be unique (technically, could be even omitted).