### PR TITLE
DBZ-3541: Parse integer default value as float and round

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
@@ -504,4 +504,17 @@ public class MySqlDefaultValueTest {
         assertThat(Byte.toUnsignedInt((defVal[1]))).isEqualTo(0b11111011);
         assertThat(Byte.toUnsignedInt((defVal[2]))).isEqualTo(0b11111111);
     }
+
+    @Test
+    @FixFor("DBZ-3541")
+    public void shouldRoundIntExpressedAsDecimal() {
+        String ddl = "CREATE TABLE int_as_decimal (col1 INT DEFAULT '0.0', col2 INT DEFAULT '1.5')";
+
+        parser.parse(ddl, tables);
+
+        Table table = tables.forTable(new TableId(null, null, "int_as_decimal"));
+
+        assertThat(table.columnWithName("col1").defaultValue()).isEqualTo(0);
+        assertThat(table.columnWithName("col2").defaultValue()).isEqualTo(2);
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -889,7 +889,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
                 r.deliver(NumberConversions.getInteger((Boolean) data));
             }
             else if (data instanceof String) {
-                r.deliver(Integer.valueOf((String) data));
+                r.deliver(Math.round(Float.parseFloat((String) data)));
             }
         });
     }


### PR DESCRIPTION
It looks like MySQL rounds the default value internally:
```sql
CREATE TABLE `foo15` (
    id INTEGER DEFAULT '1.5'
);
SHOW CREATE TABLE foo15;

-- CREATE TABLE `foo15` (
--   `id` int(11) DEFAULT '2'
-- )
```