### PR TITLE
DBZ-0000: [CXP-1145] Disconnect before schema recovery

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -93,7 +93,26 @@ public class MySqlConnectorTask extends BaseSourceTask {
 
         this.schema = new MySqlDatabaseSchema(connectorConfig, valueConverters, topicSelector, schemaNameAdjuster, tableIdCaseInsensitive);
 
+        LOGGER.info("Closing connection before starting schema recovery");
+
+        try {
+            connection.close();
+        }
+        catch (SQLException e) {
+            throw new DebeziumException(e);
+        }
+
         validateAndLoadDatabaseHistory(connectorConfig, previousOffset, schema);
+
+        LOGGER.info("Reconnecting after finishing schema recovery");
+
+        try {
+            connection.setAutoCommit(false);
+        }
+        catch (SQLException e) {
+            throw new DebeziumException(e);
+        }
+
         // If the binlog position is not available it is necessary to reexecute snapshot
         if (validateSnapshotFeasibility(connectorConfig, previousOffset)) {
             previousOffset = null;


### PR DESCRIPTION
This is an attempt to mitigate the idle connection timeout. The connector will disconnect before schema recovery and reconnect afterward. This approach has been verified in k8s-usw2-dev using the following patch: https://github.com/sugarcrm/debezium/blob/64ca504ef4e935a5b3d0fc014c4d357a4a9f22df/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java#L96-L119

The logs in the worker pod would look like the following:
```
{
  "@timestamp": "2021-05-28T20:32:54.936Z",
  "source_host": "cxp-connect-connect-7bfc7465c8-8hkw4",
  "file": "MySqlConnectorTask.java",
  "method": "start",
  "level": "ERROR",
  "line_number": "96",
  "thread_name": "task-thread-cxp-demo-us-west-2-609981f76d6333715470ed29-cdc-source-0",
  "@version": 1,
  "logger_name": "io.debezium.connector.mysql.MySqlConnectorTask",
  "message": "Closing connection before starting schema recovery",
  "class": "io.debezium.connector.mysql.MySqlConnectorTask",
  "mdc": {
    "connector.context": "[cxp-demo-us-west-2-609981f76d6333715470ed29-cdc-source|task-0] "
  }
}
...
May 28, 2021 8:43:14 PM com.github.shyiko.mysql.binlog.BinaryLogClient tryUpgradeToSSL
INFO: SSL enabled
May 28, 2021 8:43:14 PM com.github.shyiko.mysql.binlog.BinaryLogClient connect
INFO: Connected to cxp-demo-ac-1.cluster-c1jkvsjbpkil.us-west-2.rds.amazonaws.com:3306 at mysql-bin-changelog.000012/43049699 (sid:6401, cid:79962)
```