### PR TITLE
DBZ-2975: CXP-1337: make listOfChangeTables LSN interval aware

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -359,22 +359,12 @@ public class SqlServerConnection extends JdbcConnection {
     }
 
     public Set<SqlServerChangeTable> listOfChangeTables(String databaseName) throws SQLException {
-        Map<Integer, List<String>> columns = queryAndMap(
-                GET_LIST_OF_CDC_ENABLED_COLUMNS.replace(DATABASE_NAME_PLACEHOLDER, databaseName),
-                rs -> {
-                    Map<Integer, List<String>> result = new HashMap<>();
-                    while (rs.next()) {
-                        int changeTableObjectId = rs.getInt(1);
-                        if (!result.containsKey(changeTableObjectId)) {
-                            result.put(changeTableObjectId, new LinkedList<>());
-                        }
+        return listOfChangeTables(databaseName, Lsn.NULL, Lsn.NULL);
+    }
 
-                        result.get(changeTableObjectId).add(rs.getString(3));
-                    }
-                    return result;
-                });
-
-        return queryAndMap(GET_LIST_OF_CDC_ENABLED_TABLES.replace(DATABASE_NAME_PLACEHOLDER, databaseName), rs -> {
+    public Set<SqlServerChangeTable> listOfChangeTables(String databaseName, Lsn fromLsn, Lsn toLsn) throws SQLException {
+        final Map<Integer, List<String>> columns = listOfChangeColumns(databaseName);
+        final ResultSetMapper<Set<SqlServerChangeTable>> mapper = rs -> {
             final Set<SqlServerChangeTable> changeTables = new HashSet<>();
             while (rs.next()) {
                 int changeTableObjectId = rs.getInt(4);
@@ -388,6 +378,44 @@ public class SqlServerConnection extends JdbcConnection {
                                 columns.get(changeTableObjectId)));
             }
             return changeTables;
+        };
+
+        String query = GET_LIST_OF_CDC_ENABLED_TABLES.replace(DATABASE_NAME_PLACEHOLDER, databaseName);
+        if (fromLsn.getBinary() == null && toLsn.getBinary() == null) {
+            return queryAndMap(query, mapper);
+        }
+
+        if (fromLsn.getBinary() == null) {
+            return prepareQueryAndMap(query + " WHERE ct.start_lsn <= ?",
+                    ps -> ps.setBytes(1, toLsn.getBinary()),
+                    mapper);
+        }
+
+        if (toLsn.getBinary() == null) {
+            return prepareQueryAndMap(query + " WHERE ct.end_lsn >= ? OR ct.end_lsn IS NULL",
+                    ps -> ps.setBytes(1, fromLsn.getBinary()),
+                    mapper);
+        }
+
+        return prepareQueryAndMap(query + " WHERE ct.start_lsn <= ? AND (ct.end_lsn >= ? OR ct.end_lsn IS NULL)", ps -> {
+            ps.setBytes(1, toLsn.getBinary());
+            ps.setBytes(2, fromLsn.getBinary());
+        }, mapper);
+    }
+
+    private Map<Integer, List<String>> listOfChangeColumns(String databaseName) throws SQLException {
+        final String cdcColumnsQuery = GET_LIST_OF_CDC_ENABLED_COLUMNS.replace(DATABASE_NAME_PLACEHOLDER, databaseName);
+        return queryAndMap(cdcColumnsQuery, rs -> {
+            Map<Integer, List<String>> result = new HashMap<>();
+            while (rs.next()) {
+                int changeTableObjectId = rs.getInt(1);
+                if (!result.containsKey(changeTableObjectId)) {
+                    result.put(changeTableObjectId, new LinkedList<>());
+                }
+
+                result.get(changeTableObjectId).add(rs.getString(3));
+            }
+            return result;
         });
     }
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
@@ -9,7 +9,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -200,7 +199,7 @@ public class SqlServerOffsetContext implements OffsetContext {
     }
 
     public void saveStreamingExecutionContext(Queue<SqlServerChangeTable> schemaChangeCheckpoints,
-                                              AtomicReference<SqlServerChangeTable[]> tablesSlot,
+                                              SqlServerChangeTable[] tablesSlot,
                                               TxLogPosition lastProcessedPositionOnStart,
                                               long lastProcessedEventSerialNoOnStart,
                                               TxLogPosition lastProcessedPosition,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -16,7 +16,6 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -114,7 +113,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
 
         Queue<SqlServerChangeTable> schemaChangeCheckpoints = new PriorityQueue<>((x, y) -> x.getStopLsn().compareTo(y.getStopLsn()));
         try {
-            AtomicReference<SqlServerChangeTable[]> tablesSlot;
+            SqlServerChangeTable[] tablesSlot = new SqlServerChangeTable[0];
 
             TxLogPosition lastProcessedPositionOnStart = offsetContext.getChangePosition();
             long lastProcessedEventSerialNoOnStart = offsetContext.getEventSerialNo();
@@ -127,18 +126,24 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             // otherwise we might skip an incomplete transaction after restart
             boolean shouldIncreaseFromLsn = offsetContext.isSnapshotCompleted();
 
-            if (offsetContext.getStreamingExecutionState() != null && offsetContext.getStreamingExecutionState().getTablesSlot() != null) {
+            boolean hasExecutionState = offsetContext.getStreamingExecutionState() != null;
+            boolean hasInitializedTableSlot = hasExecutionState
+                    && offsetContext.getStreamingExecutionState().getTablesSlot() != null
+                    && offsetContext.getStreamingExecutionState().getTablesSlot().length > 0;
+            if (hasExecutionState) {
                 schemaChangeCheckpoints = offsetContext.getStreamingExecutionState().getSchemaChangeCheckpoints();
-                tablesSlot = offsetContext.getStreamingExecutionState().getTablesSlot();
                 lastProcessedPositionOnStart = offsetContext.getStreamingExecutionState().getLastProcessedPositionOnStart();
                 lastProcessedEventSerialNoOnStart = offsetContext.getStreamingExecutionState().getLastProcessedEventSerialNoOnStart();
                 changesStoppedBeingMonotonic = offsetContext.getStreamingExecutionState().getChangesStoppedBeingMonotonic();
 
                 lastProcessedPosition = offsetContext.getStreamingExecutionState().getLastProcessedPosition();
                 shouldIncreaseFromLsn = offsetContext.getStreamingExecutionState().getShouldIncreaseFromLsn();
+
+                if (hasInitializedTableSlot) {
+                    tablesSlot = offsetContext.getStreamingExecutionState().getTablesSlot();
+                }
             }
             else {
-                tablesSlot = new AtomicReference<>(getCdcTablesToQuery(partition, offsetContext));
                 LOGGER.info("Last position recorded in offsets is {}[{}]", lastProcessedPositionOnStart, lastProcessedEventSerialNoOnStart);
             }
 
@@ -173,28 +178,33 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                 while (!schemaChangeCheckpoints.isEmpty()) {
                     migrateTable(partition, schemaChangeCheckpoints, offsetContext);
                 }
+
+                if (!hasInitializedTableSlot) {
+                    tablesSlot = getCdcTablesToQuery(partition, offsetContext, fromLsn, toLsn);
+                }
+
                 if (!dataConnection.listOfNewChangeTables(partition.getDatabaseName(), fromLsn, toLsn).isEmpty()) {
-                    final SqlServerChangeTable[] tables = getCdcTablesToQuery(partition, offsetContext);
-                    tablesSlot.set(tables);
-                    for (SqlServerChangeTable table : tables) {
+                    tablesSlot = getCdcTablesToQuery(partition, offsetContext, fromLsn, toLsn);
+                    for (SqlServerChangeTable table : tablesSlot) {
                         if (table.getStartLsn().isBetween(fromLsn, toLsn)) {
                             LOGGER.info("Schema will be changed for {}", table);
                             schemaChangeCheckpoints.add(table);
                         }
                     }
                 }
+
                 try {
-                    AtomicReference<SqlServerChangeTable[]> finalTablesSlot = tablesSlot;
+                    SqlServerChangeTable[] finalTablesSlot = tablesSlot;
                     AtomicBoolean finalChangesStoppedBeingMonotonic = changesStoppedBeingMonotonic;
                     TxLogPosition finalLastProcessedPositionOnStart = lastProcessedPositionOnStart;
                     long finalLastProcessedEventSerialNoOnStart = lastProcessedEventSerialNoOnStart;
                     Queue<SqlServerChangeTable> finalSchemaChangeCheckpoints = schemaChangeCheckpoints;
-                    dataConnection.getChangesForTables(partition.getDatabaseName(), tablesSlot.get(), fromLsn, toLsn, resultSets -> {
+                    dataConnection.getChangesForTables(partition.getDatabaseName(), tablesSlot, fromLsn, toLsn, resultSets -> {
 
                         long eventSerialNoInInitialTx = 1;
                         final int tableCount = resultSets.length;
                         final SqlServerChangeTablePointer[] changeTables = new SqlServerChangeTablePointer[tableCount];
-                        final SqlServerChangeTable[] tables = finalTablesSlot.get();
+                        final SqlServerChangeTable[] tables = finalTablesSlot;
 
                         for (int i = 0; i < tableCount; i++) {
                             changeTables[i] = new SqlServerChangeTablePointer(tables[i], resultSets[i],
@@ -307,7 +317,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                     dataConnection.rollback();
                 }
                 catch (SQLException e) {
-                    tablesSlot.set(processErrorFromChangeTableQuery(e, tablesSlot.get(), partition));
+                    tablesSlot = processErrorFromChangeTableQuery(e, tablesSlot, partition);
                 }
             }
 
@@ -359,8 +369,9 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
         throw exception;
     }
 
-    private SqlServerChangeTable[] getCdcTablesToQuery(SqlServerPartition partition, SqlServerOffsetContext offsetContext) throws SQLException, InterruptedException {
-        final Set<SqlServerChangeTable> cdcEnabledTables = dataConnection.listOfChangeTables(partition.getDatabaseName());
+    private SqlServerChangeTable[] getCdcTablesToQuery(SqlServerPartition partition, SqlServerOffsetContext offsetContext, Lsn fromLsn, Lsn toLsn)
+            throws SQLException, InterruptedException {
+        final Set<SqlServerChangeTable> cdcEnabledTables = dataConnection.listOfChangeTables(partition.getDatabaseName(), fromLsn, toLsn);
         if (cdcEnabledTables.isEmpty()) {
             LOGGER.warn("No table has enabled CDC or security constraints prevents getting the list of change tables");
         }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingExecutionState.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingExecutionState.java
@@ -7,11 +7,10 @@ package io.debezium.connector.sqlserver;
 
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class SqlServerStreamingExecutionState {
     private final Queue<SqlServerChangeTable> schemaChangeCheckpoints;
-    private final AtomicReference<SqlServerChangeTable[]> tablesSlot;
+    private final SqlServerChangeTable[] tablesSlot;
     private final TxLogPosition lastProcessedPositionOnStart;
     private final long lastProcessedEventSerialNoOnStart;
     private final TxLogPosition lastProcessedPosition;
@@ -24,7 +23,7 @@ public class SqlServerStreamingExecutionState {
     }
 
     SqlServerStreamingExecutionState(Queue<SqlServerChangeTable> schemaChangeCheckpoints,
-                                     AtomicReference<SqlServerChangeTable[]> tablesSlot,
+                                     SqlServerChangeTable[] tablesSlot,
                                      TxLogPosition lastProcessedPositionOnStart,
                                      long lastProcessedEventSerialNoOnStart,
                                      TxLogPosition lastProcessedPosition,
@@ -45,7 +44,7 @@ public class SqlServerStreamingExecutionState {
         return schemaChangeCheckpoints;
     }
 
-    public AtomicReference<SqlServerChangeTable[]> getTablesSlot() {
+    public SqlServerChangeTable[] getTablesSlot() {
         return tablesSlot;
     }
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
@@ -186,38 +186,45 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
 
     @Test
     public void addColumnToTableEndOfBatchWithoutLsnLimit() throws Exception {
-        addColumnToTable(true, false);
+        final Configuration config = TestHelper.defaultMultiDatabaseConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .build();
+        addColumnToTable(config, true);
     }
 
     @Test
     public void addColumnToTableEndOfBatchWithLsnLimit() throws Exception {
-        addColumnToTable(true, true);
+        final Configuration config = TestHelper.defaultMultiDatabaseConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .with(SqlServerConnectorConfig.MAX_TRANSACTIONS_PER_ITERATION, 1)
+                .build();
+        addColumnToTable(config, true);
     }
 
     @Test
     public void addColumnToTableMiddleOfBatchWithoutLsnLimit() throws Exception {
-        addColumnToTable(false, false);
+        final Configuration config = TestHelper.defaultMultiDatabaseConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .build();
+        addColumnToTable(config, false);
     }
 
     @Test
     public void addColumnToTableMiddleOfBatchWithLsnLimit() throws Exception {
-        addColumnToTable(false, true);
+        final Configuration config = TestHelper.defaultMultiDatabaseConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .with(SqlServerConnectorConfig.MAX_TRANSACTIONS_PER_ITERATION, 1)
+                .build();
+        addColumnToTable(config, true);
     }
 
-    private void addColumnToTable(boolean pauseAfterCaptureChange, boolean limitTransactionsPerIteration) throws Exception {
+    private void addColumnToTable(Configuration config, boolean pauseAfterCaptureChange) throws Exception {
         final int RECORDS_PER_TABLE = 5;
         final int TABLES = 2;
         final int ID_START_1 = 10;
         final int ID_START_2 = 100;
         final int ID_START_3 = 1000;
         final int ID_START_4 = 10000;
-
-        final Configuration.Builder builder = TestHelper.defaultMultiDatabaseConfig()
-                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY);
-        if (limitTransactionsPerIteration){
-            builder.with(SqlServerConnectorConfig.MAX_TRANSACTIONS_PER_ITERATION, 1);
-        }
-        final Configuration config = builder.build();
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
@@ -185,25 +185,39 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
     }
 
     @Test
-    public void addColumnToTableEndOfBatch() throws Exception {
-        addColumnToTable(true);
+    public void addColumnToTableEndOfBatchWithoutLsnLimit() throws Exception {
+        addColumnToTable(true, false);
     }
 
     @Test
-    public void addColumnToTableMiddleOfBatch() throws Exception {
-        addColumnToTable(false);
+    public void addColumnToTableEndOfBatchWithLsnLimit() throws Exception {
+        addColumnToTable(true, true);
     }
 
-    private void addColumnToTable(boolean pauseAfterCaptureChange) throws Exception {
+    @Test
+    public void addColumnToTableMiddleOfBatchWithoutLsnLimit() throws Exception {
+        addColumnToTable(false, false);
+    }
+
+    @Test
+    public void addColumnToTableMiddleOfBatchWithLsnLimit() throws Exception {
+        addColumnToTable(false, true);
+    }
+
+    private void addColumnToTable(boolean pauseAfterCaptureChange, boolean limitTransactionsPerIteration) throws Exception {
         final int RECORDS_PER_TABLE = 5;
         final int TABLES = 2;
         final int ID_START_1 = 10;
         final int ID_START_2 = 100;
         final int ID_START_3 = 1000;
         final int ID_START_4 = 10000;
-        final Configuration config = TestHelper.defaultMultiDatabaseConfig()
-                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
-                .build();
+
+        final Configuration.Builder builder = TestHelper.defaultMultiDatabaseConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY);
+        if (limitTransactionsPerIteration){
+            builder.with(SqlServerConnectorConfig.MAX_TRANSACTIONS_PER_ITERATION, 1);
+        }
+        final Configuration config = builder.build();
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();


### PR DESCRIPTION
Currently if we limit the number of LSNs per iteration (`max.iteration.transactions`) we do it only for queries responsible for fetching cdc data from capture instance tables. While the list of capture instances itself is not filtered. So when a schema change happens cdc queries are prepared for capture instances not belonging to the current LSN interval.
It's not a big problem on its own. But internally our LSN interval is modified per each capture instance table resulting to invalid intervals and finally errors from SQL Server. 
```
CI  |                                                                LSNs      
-------------------------------------------------------------------------->
ci1 |  A                    B
    |  |--------------------|
    |
ci2 |           C                      D
    |           |----------------------|
    |
ci3 |                                  D
    |                                  |-------------- NULL=infinity
    |                ^-----------^
    |                X           Y

ci1, ci2, ci3 : capture instances
X             : "from" LSN
Y             : "to" LSN
[X, Y]        : current LSN interval with size of "max.iteration.transactions"

Here we expect only ci1 and ci2 capture instances to be selected. While we get all 3.
```

**TODO:**
- [x] Provide the description.
- [ ] If possible, provide a test that will always fail.