### PR TITLE
CXP-1337: Filter out invalid LSNs 

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -256,6 +257,11 @@ public class SqlServerConnection extends JdbcConnection {
     public void getChangesForTables(String databaseName, SqlServerChangeTable[] changeTables, Lsn intervalFromLsn,
                                     Lsn intervalToLsn, BlockingMultiResultSetConsumer consumer)
             throws SQLException, InterruptedException {
+
+        changeTables = Arrays.stream(changeTables)
+                .filter(ct -> ct.getStartLsn().compareTo(intervalToLsn) <= 0)
+                .toArray(SqlServerChangeTable[]::new);
+
         final String[] queries = new String[changeTables.length];
         final StatementPreparer[] preparers = new StatementPreparer[changeTables.length];
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
@@ -185,25 +185,46 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
     }
 
     @Test
-    public void addColumnToTableEndOfBatch() throws Exception {
-        addColumnToTable(true);
+    public void addColumnToTableEndOfBatchWithoutLsnLimit() throws Exception {
+        final Configuration config = TestHelper.defaultMultiDatabaseConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .build();
+        addColumnToTable(config, true);
     }
 
     @Test
-    public void addColumnToTableMiddleOfBatch() throws Exception {
-        addColumnToTable(false);
+    public void addColumnToTableEndOfBatchWithLsnLimit() throws Exception {
+        final Configuration config = TestHelper.defaultMultiDatabaseConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .with(SqlServerConnectorConfig.MAX_TRANSACTIONS_PER_ITERATION, 1)
+                .build();
+        addColumnToTable(config, true);
     }
 
-    private void addColumnToTable(boolean pauseAfterCaptureChange) throws Exception {
+    @Test
+    public void addColumnToTableMiddleOfBatchWithoutLsnLimit() throws Exception {
+        final Configuration config = TestHelper.defaultMultiDatabaseConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .build();
+        addColumnToTable(config, false);
+    }
+
+    @Test
+    public void addColumnToTableMiddleOfBatchWithLsnLimit() throws Exception {
+        final Configuration config = TestHelper.defaultMultiDatabaseConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .with(SqlServerConnectorConfig.MAX_TRANSACTIONS_PER_ITERATION, 1)
+                .build();
+        addColumnToTable(config, false);
+    }
+
+    private void addColumnToTable(Configuration config, boolean pauseAfterCaptureChange) throws Exception {
         final int RECORDS_PER_TABLE = 5;
         final int TABLES = 2;
         final int ID_START_1 = 10;
         final int ID_START_2 = 100;
         final int ID_START_3 = 1000;
         final int ID_START_4 = 10000;
-        final Configuration config = TestHelper.defaultMultiDatabaseConfig()
-                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
-                .build();
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();


### PR DESCRIPTION
Currently if we limit the number of LSNs per iteration (`max.iteration.transactions`) we do it only for queries responsible for fetching cdc data from capture instance tables. While the list of capture instances itself is not filtered. So when a schema change happens cdc queries are prepared for capture instances not belonging to the current LSN interval.
It's not a big problem on its own. But internally our LSN interval is modified per each capture instance table resulting to invalid intervals and finally errors from SQL Server. 
```
CI  |                                                                LSNs      
-------------------------------------------------------------------------->
ci1 |  A                    B
    |  |--------------------|
    |
ci2 |           C                      D
    |           |----------------------|
    |
ci3 |                                  D
    |                                  |-------------- NULL=infinity
    |                ^-----------^
    |                X           Y

ci1, ci2, ci3 : capture instances
X             : "from" LSN
Y             : "to" LSN
[X, Y]        : current LSN interval with size of "max.iteration.transactions"

Here we expect only ci1 and ci2 capture instances to be selected. While we get all 3.
```

**TODO:**
- [x] Provide the description
- [ ] If possible, provide a test that will always fail

Previous PR: #85 