### PR TITLE
[CXP-1546] SQL Server connector fails during a database transition into read-only mode

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
@@ -32,6 +32,8 @@ public class SqlServerErrorHandler extends ErrorHandler {
                         || throwable.getMessage().contains("Connection timed out (Write failed)")
                         || throwable.getMessage().contains("The connection has been closed.")
                         || throwable.getMessage().contains("The connection is closed.")
+                        || throwable.getMessage().contains("The login failed.")
+                        || throwable.getMessage().contains("Try the statement later.")
                         || throwable.getMessage().contains("Connection reset")
                         || throwable.getMessage().contains("SHUTDOWN is in progress")
                         || throwable.getMessage().contains("The server failed to resume the transaction")


### PR DESCRIPTION
Depending on the 1:1 or the 1:M mode, either of the errors can occur when the database is in transition.