### PR TITLE
[CXP-1553] Filter out capture instances with the same start_lsn

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTable.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTable.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.sqlserver;
 
-import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
@@ -21,7 +20,7 @@ import io.debezium.relational.TableId;
  * @author Jiri Pechanec
  *
  */
-public class SqlServerChangeTable extends ChangeTable implements Comparable<SqlServerChangeTable> {
+public class SqlServerChangeTable extends ChangeTable {
 
     private static final String CDC_SCHEMA = "cdc";
 
@@ -36,29 +35,21 @@ public class SqlServerChangeTable extends ChangeTable implements Comparable<SqlS
     private Lsn stopLsn;
 
     /**
-     * The date of the change table creation
-     */
-    private final Instant createDate;
-
-    /**
      * List of columns captured by the CDC table.
      */
     @Immutable
     private final List<String> capturedColumns;
 
-    public SqlServerChangeTable(TableId sourceTableId, String captureInstance, int changeTableObjectId,
-                                Lsn startLsn, Lsn stopLsn, Instant createDate,
+    public SqlServerChangeTable(TableId sourceTableId, String captureInstance, int changeTableObjectId, Lsn startLsn, Lsn stopLsn,
                                 List<String> capturedColumns) {
         super(captureInstance, sourceTableId, resolveChangeTableId(sourceTableId, captureInstance), changeTableObjectId);
         this.startLsn = startLsn;
         this.stopLsn = stopLsn;
-        this.createDate = createDate;
         this.capturedColumns = capturedColumns != null ? Collections.unmodifiableList(capturedColumns) : Collections.emptyList();
     }
 
-    public SqlServerChangeTable(String captureInstance, int changeTableObjectId, Lsn startLsn, Lsn stopLsn,
-                                Instant createDate) {
-        this(null, captureInstance, changeTableObjectId, startLsn, stopLsn, createDate, null);
+    public SqlServerChangeTable(String captureInstance, int changeTableObjectId, Lsn startLsn, Lsn stopLsn) {
+        this(null, captureInstance, changeTableObjectId, startLsn, stopLsn, null);
     }
 
     public Lsn getStartLsn() {
@@ -67,10 +58,6 @@ public class SqlServerChangeTable extends ChangeTable implements Comparable<SqlS
 
     public Lsn getStopLsn() {
         return stopLsn;
-    }
-
-    public Instant getCreateDate() {
-        return createDate;
     }
 
     public void setStopLsn(Lsn stopLsn) {
@@ -85,24 +72,10 @@ public class SqlServerChangeTable extends ChangeTable implements Comparable<SqlS
     public String toString() {
         return "Capture instance \"" + getCaptureInstance() + "\" [sourceTableId=" + getSourceTableId()
                 + ", changeTableId=" + getChangeTableId() + ", startLsn=" + startLsn + ", changeTableObjectId="
-                + getChangeTableObjectId() + ", stopLsn=" + stopLsn + ", createDate=" + createDate + "]";
+                + getChangeTableObjectId() + ", stopLsn=" + stopLsn + "]";
     }
 
     private static TableId resolveChangeTableId(TableId sourceTableId, String captureInstance) {
         return sourceTableId != null ? new TableId(sourceTableId.catalog(), CDC_SCHEMA, captureInstance + "_CT") : null;
-    }
-
-    @Override
-    public int compareTo(SqlServerChangeTable o) {
-        if (this == o) {
-            return 0;
-        }
-
-        int comparison = getStartLsn().compareTo(o.getStartLsn());
-        if (comparison != 0) {
-            return comparison;
-        }
-
-        return getCreateDate().compareTo(o.getCreateDate());
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -185,7 +185,7 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
                 .listOfChangeTables(snapshotContext.partition.getDatabaseName())
                 .stream()
                 .collect(Collectors.toMap(SqlServerChangeTable::getSourceTableId, changeTable -> changeTable,
-                        (changeTable1, changeTable2) -> changeTable1.compareTo(changeTable2) > 0
+                        (changeTable1, changeTable2) -> changeTable1.getStartLsn().compareTo(changeTable2.getStartLsn()) > 0
                                 ? changeTable1
                                 : changeTable2));
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -395,7 +395,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             SqlServerChangeTable currentTable = captures.get(0);
             if (captures.size() > 1) {
                 SqlServerChangeTable futureTable;
-                if (captures.get(0).compareTo(captures.get(1)) < 0) {
+                if (captures.get(0).getStartLsn().compareTo(captures.get(1).getStartLsn()) < 0) {
                     futureTable = captures.get(1);
                 }
                 else {
@@ -406,9 +406,6 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                 futureTable.setSourceTable(dataConnection.getTableSchemaFromTable(databaseName, futureTable));
                 tables.add(futureTable);
                 LOGGER.info("Multiple capture instances present for the same table: {} and {}", currentTable, futureTable);
-                if (currentTable.getStartLsn().equals(futureTable.getStartLsn())) {
-                    LOGGER.info("Both {} and {} have the same start LSN", currentTable, futureTable);
-                }
             }
             if (schema.tableFor(currentTable.getSourceTableId()) == null) {
                 LOGGER.info("Table {} is new to be monitored by capture instance {}", currentTable.getSourceTableId(), currentTable.getCaptureInstance());

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
@@ -202,7 +202,7 @@ public class SqlServerConnectionIT {
                         "varbinary_column", "image_column");
 
                 SqlServerChangeTable changeTable = new SqlServerChangeTable(new TableId(databaseName, "dbo", "table_with_defaults"),
-                        null, 0, null, null, null, capturedColumns);
+                        null, 0, null, null, capturedColumns);
                 Table table = connection.getTableSchemaFromTable(databaseName, changeTable);
 
                 assertColumnHasNotDefaultValue(table, "int_no_default_not_null");
@@ -353,7 +353,7 @@ public class SqlServerConnectionIT {
                                 "real_column");
 
                 SqlServerChangeTable changeTable = new SqlServerChangeTable(new TableId(databaseName, "dbo", "table_with_defaults"),
-                        null, 0, null, null, null, capturedColumns);
+                        null, 0, null, null, capturedColumns);
                 Table table = connection.getTableSchemaFromTable(databaseName, changeTable);
 
                 assertColumnHasNotDefaultValue(table, "int_no_default_not_null");


### PR DESCRIPTION
1. Revert the logic implemented in #97, since the comparison by `create_date` is now implemented in SQL.
2. Filter out duplicates in SQL. This will eliminate the need to implement this logic in multiple places on the client side where this comparison wasn't implemented by the previous patch.
3. Try not to select `end_lsn` since it's always NULL ([ref](https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sys-sp-cdc-help-change-data-capture-transact-sql?view=sql-server-2016#result-sets)). The existing logic that relies on it must be redundant.
4. Do not filter capture instances by `end_lsn` since it's always NULL.