### PR TITLE
[CXP-1554] Handle error 18401 "Login failed for user..." as retriable

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
@@ -33,6 +33,7 @@ public class SqlServerErrorHandler extends ErrorHandler {
                         || throwable.getMessage().contains("The connection has been closed.")
                         || throwable.getMessage().contains("The connection is closed.")
                         || throwable.getMessage().contains("The login failed.")
+                        || throwable.getMessage().contains("Login failed for user")
                         || throwable.getMessage().contains("Try the statement later.")
                         || throwable.getMessage().contains("Connection reset")
                         || throwable.getMessage().contains("SHUTDOWN is in progress")


### PR DESCRIPTION
From the [documentation](https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors?view=sql-server-ver15):

| Error  | Description |
| ------------- | ------------- |
| 18401  | Login failed for user '%.*ls'. Reason: Server is in script upgrade mode. Only administrator can connect at this time.%.*ls |
