### PR TITLE
[CXP-1566] Change "No maximum LSN recorded" log message to debug level

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -149,7 +149,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
 
                 // Shouldn't happen if the agent is running, but it is better to guard against such situation
                 if (!toLsn.isAvailable()) {
-                    LOGGER.warn("No maximum LSN recorded in the database \"{}\"; please ensure that the SQL Server Agent is running", partition.getDatabaseName());
+                    LOGGER.debug("No maximum LSN recorded in the database \"{}\"; please ensure that the SQL Server Agent is running", partition.getDatabaseName());
                     return;
                 }
                 // There is no change in the database


### PR DESCRIPTION
The "No maximum LSN recorded ..." log message will spam the log in production on databases with low or no activity. This is due to the `getNthTransactionLsnFromLast` being used to retrieve the `toLsn`. During low activity this call will return `NULL` resulting in this message being emitted.