### PR TITLE
[CXP-1523] Notify the database of streaming and snapshot events.

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -56,7 +56,8 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
                 dispatcher,
                 errorHandler,
                 clock,
-                schema);
+                schema,
+                new SqlServerStreamingDatabaseNotifier(dataConnection));
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.sqlserver;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.debezium.pipeline.ErrorHandler;
@@ -42,9 +43,10 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
     }
 
     @Override
-    public SnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> getSnapshotChangeEventSource(List<SnapshotProgressListener> snapshotProgressListeners) {
+        snapshotProgressListeners.add(new SqlServerSnapshotDatabaseNotifier(dataConnection));
         return new SqlServerSnapshotChangeEventSource(configuration, dataConnection, schema, dispatcher, clock,
-                snapshotProgressListener);
+                snapshotProgressListeners);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -561,7 +561,7 @@ public class SqlServerConnection extends JdbcConnection {
         return "[" + tableId.catalog() + "].[" + tableId.schema() + "].[" + tableId.table() + "]";
     }
 
-    private String replaceDatabaseNamePlaceholder(String sql, String databaseName) {
+    public String replaceDatabaseNamePlaceholder(String sql, String databaseName) {
         return sql.replace(DATABASE_NAME_PLACEHOLDER, databaseName);
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -47,8 +47,8 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
 
     public SqlServerSnapshotChangeEventSource(SqlServerConnectorConfig connectorConfig, SqlServerConnection jdbcConnection,
                                               SqlServerDatabaseSchema schema, EventDispatcher<TableId> dispatcher, Clock clock,
-                                              SnapshotProgressListener snapshotProgressListener) {
-        super(connectorConfig, jdbcConnection, schema, dispatcher, clock, snapshotProgressListener);
+                                              List<SnapshotProgressListener> snapshotProgressListeners) {
+        super(connectorConfig, jdbcConnection, schema, dispatcher, clock, snapshotProgressListeners);
         this.connectorConfig = connectorConfig;
         this.jdbcConnection = jdbcConnection;
         this.sqlServerDatabaseSchema = schema;

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotDatabaseNotifier.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotDatabaseNotifier.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionId;
+
+/**
+ * A class invoked by {@link SnapshotChangeEventSource} to notify the database of events via stored procedures
+ *
+ * @author Jacob Gminder
+ */
+public class SqlServerSnapshotDatabaseNotifier implements SnapshotProgressListener {
+    private final SqlServerConnection dataConnection;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerSnapshotDatabaseNotifier.class);
+
+    SqlServerSnapshotDatabaseNotifier(final SqlServerConnection dataConnection) {
+        this.dataConnection = dataConnection;
+    }
+
+    @Override
+    public void snapshotStarted(Partition partition) {
+        SqlServerPartition sqlServerPartition = (SqlServerPartition) partition;
+        LOGGER.info("Started snapshot of database: {}", sqlServerPartition.getDatabaseName());
+        // TODO
+    }
+
+    @Override
+    public void monitoredDataCollectionsDetermined(Partition partition, Iterable<? extends DataCollectionId> dataCollectionIds) {
+        // Do nothing
+    }
+
+    @Override
+    public void snapshotCompleted(Partition partition) {
+        SqlServerPartition sqlServerPartition = (SqlServerPartition) partition;
+        LOGGER.info("Completed snapshot of database: {}", sqlServerPartition.getDatabaseName());
+        // TODO
+    }
+
+    @Override
+    public void snapshotAborted(Partition partition) {
+        SqlServerPartition sqlServerPartition = (SqlServerPartition) partition;
+        LOGGER.info("Aborted snapshot of database: {}", sqlServerPartition.getDatabaseName());
+        // TODO
+    }
+
+    @Override
+    public void dataCollectionSnapshotCompleted(Partition partition, DataCollectionId dataCollectionId, long numRows) {
+        SqlServerPartition sqlServerPartition = (SqlServerPartition) partition;
+        LOGGER.info("Completed snapshot of database: {}, dataCollectionId: {}", sqlServerPartition.getDatabaseName(), dataCollectionId.identifier());
+        // TODO
+    }
+
+    @Override
+    public void rowsScanned(Partition partition, TableId tableId, long numRows) {
+        // Do nothing
+    }
+
+    @Override
+    public void currentChunk(Partition partition, String chunkId, Object[] chunkFrom, Object[] chunkTo) {
+        // Do nothing
+    }
+
+    @Override
+    public void currentChunk(Partition partition, String chunkId, Object[] chunkFrom, Object[] chunkTo, Object[] tableTo) {
+        // Do nothing
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -29,6 +29,7 @@ import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotMode;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.pipeline.source.spi.StreamingProgressListener;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.schema.SchemaChangeEvent.SchemaChangeEventType;
@@ -79,6 +80,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
 
     private final EventDispatcher<TableId> dispatcher;
     private final ErrorHandler errorHandler;
+    private final StreamingProgressListener streamingProgressListener;
     private final Clock clock;
     private final SqlServerDatabaseSchema schema;
     private final Duration pollInterval;
@@ -89,12 +91,13 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
 
     public SqlServerStreamingChangeEventSource(SqlServerConnectorConfig connectorConfig, SqlServerConnection dataConnection,
                                                SqlServerConnection metadataConnection, EventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock,
-                                               SqlServerDatabaseSchema schema) {
+                                               SqlServerDatabaseSchema schema, StreamingProgressListener streamingProgressListener) {
         this.connectorConfig = connectorConfig;
         this.dataConnection = dataConnection;
         this.metadataConnection = metadataConnection;
         this.dispatcher = dispatcher;
         this.errorHandler = errorHandler;
+        this.streamingProgressListener = streamingProgressListener;
         this.clock = clock;
         this.schema = schema;
         this.pollInterval = connectorConfig.getPollInterval();
@@ -331,6 +334,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                 new SqlServerSchemaChangeEventEmitter(partition, offsetContext, newTable, tableSchema,
                         SchemaChangeEventType.ALTER));
         newTable.setSourceTable(tableSchema);
+        streamingProgressListener.onReadingNewChangeTable(partition, newTable);
     }
 
     private SqlServerChangeTable[] processErrorFromChangeTableQuery(String databaseName, SQLException exception,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingDatabaseNotifier.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingDatabaseNotifier.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.sql.SQLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.pipeline.source.spi.StreamingProgressListener;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.ChangeTable;
+
+/**
+ * A class invoked by {@link StreamingChangeEventSource} to notify the database of events via stored procedures
+ *
+ * @author Jacob Gminder
+ */
+public class SqlServerStreamingDatabaseNotifier implements StreamingProgressListener {
+    private final SqlServerConnection dataConnection;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerStreamingDatabaseNotifier.class);
+    private static final String START_READING_CHANGE_TABLE = "EXEC [#db].dbo.DebeziumSQLConnector_StartReadingFromCaptureInstance @CaptureInstanceName = N'%s'";
+
+    SqlServerStreamingDatabaseNotifier(final SqlServerConnection dataConnection) {
+        this.dataConnection = dataConnection;
+    }
+
+    public void onReadingNewChangeTable(Partition partition, ChangeTable table) {
+        SqlServerPartition sqlServerPartition = (SqlServerPartition) partition;
+        final String query = dataConnection.replaceDatabaseNamePlaceholder(START_READING_CHANGE_TABLE, sqlServerPartition.getDatabaseName());
+        final String startReadingChangeTableStmt = String.format(query, table.getCaptureInstance());
+        try {
+            LOGGER.trace("Calling the StartReadingFromCaptureInstance stored procedure for database: {} with capture instance: {}", sqlServerPartition.getDatabaseName(),
+                    table.getCaptureInstance());
+            dataConnection.execute(startReadingChangeTableStmt);
+        }
+        catch (SQLException ex) {
+            LOGGER.trace(ex.getMessage());
+        }
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -6,7 +6,9 @@
 package io.debezium.pipeline;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -32,6 +34,7 @@ import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContex
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Offsets;
@@ -108,7 +111,11 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                     LOGGER.info("Context created");
 
                     Offsets<P, O> streamingOffsets = new Offsets<>(new HashMap<>());
-                    SnapshotChangeEventSource<P, O> snapshotSource = changeEventSourceFactory.getSnapshotChangeEventSource(snapshotMetrics);
+
+                    List<SnapshotProgressListener> snapshotProgressListeners = new ArrayList<>();
+                    snapshotProgressListeners.add(snapshotMetrics);
+
+                    SnapshotChangeEventSource<P, O> snapshotSource = changeEventSourceFactory.getSnapshotChangeEventSource(snapshotProgressListeners);
 
                     for (Map.Entry<P, O> entry : previousOffsets.getOffsets().entrySet()) {
                         P partition = entry.getKey();

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
@@ -7,6 +7,7 @@ package io.debezium.pipeline.source;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -37,11 +38,11 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSnapshotChangeEventSource.class);
 
     private final CommonConnectorConfig connectorConfig;
-    private final SnapshotProgressListener snapshotProgressListener;
+    private final List<SnapshotProgressListener> snapshotProgressListeners;
 
-    public AbstractSnapshotChangeEventSource(CommonConnectorConfig connectorConfig, SnapshotProgressListener snapshotProgressListener) {
+    public AbstractSnapshotChangeEventSource(CommonConnectorConfig connectorConfig, List<SnapshotProgressListener> snapshotProgressListeners) {
         this.connectorConfig = connectorConfig;
-        this.snapshotProgressListener = snapshotProgressListener;
+        this.snapshotProgressListeners = snapshotProgressListeners;
     }
 
     @Override
@@ -66,7 +67,7 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
         boolean completedSuccessfully = true;
 
         try {
-            snapshotProgressListener.snapshotStarted(partition);
+            snapshotProgressListeners.forEach(snapshotProgressListener -> snapshotProgressListener.snapshotStarted(partition));
             return doExecute(context, previousOffset, ctx, snapshottingTask);
         }
         catch (InterruptedException e) {
@@ -83,10 +84,10 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
             complete(ctx);
 
             if (completedSuccessfully) {
-                snapshotProgressListener.snapshotCompleted(partition);
+                snapshotProgressListeners.forEach(snapshotProgressListener -> snapshotProgressListener.snapshotCompleted(partition));
             }
             else {
-                snapshotProgressListener.snapshotAborted(partition);
+                snapshotProgressListeners.forEach(snapshotProgressListener -> snapshotProgressListener.snapshotAborted(partition));
             }
         }
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.pipeline.source.spi;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
@@ -26,12 +27,12 @@ public interface ChangeEventSourceFactory<P extends Partition, O extends OffsetC
      * {@link StreamingChangeEventSource#execute(ChangeEventSource.ChangeEventSourceContext, Partition, io.debezium.pipeline.spi.OffsetContext)}
      * method.
      *
-     * @param snapshotProgressListener
-     *            A listener called for changes in the state of snapshot. May be {@code null}.
+     * @param snapshotProgressListeners
+     *            The listeners called for changes in the state of snapshot. May be {@code null}.
      *
      * @return A snapshot change event source
      */
-    SnapshotChangeEventSource<P, O> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener);
+    SnapshotChangeEventSource<P, O> getSnapshotChangeEventSource(List<SnapshotProgressListener> snapshotProgressListeners);
 
     /**
      * Returns a streaming change event source that starts streaming at the given offset.

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingProgressListener.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingProgressListener.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.spi;
+
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.ChangeTable;
+
+/**
+ * A class invoked by {@link StreamingChangeEventSource} whenever an important event or change of state happens.
+ *
+ * @author Jacob Gminder
+ */
+public interface StreamingProgressListener {
+
+    void onReadingNewChangeTable(Partition partition, ChangeTable table);
+}

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -68,18 +68,18 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
     private final RelationalDatabaseSchema schema;
     protected final EventDispatcher<TableId> dispatcher;
     protected final Clock clock;
-    private final SnapshotProgressListener snapshotProgressListener;
+    private final List<SnapshotProgressListener> snapshotProgressListeners;
 
     public RelationalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig connectorConfig,
                                                JdbcConnection jdbcConnection, RelationalDatabaseSchema schema,
-                                               EventDispatcher<TableId> dispatcher, Clock clock, SnapshotProgressListener snapshotProgressListener) {
-        super(connectorConfig, snapshotProgressListener);
+                                               EventDispatcher<TableId> dispatcher, Clock clock, List<SnapshotProgressListener> snapshotProgressListeners) {
+        super(connectorConfig, snapshotProgressListeners);
         this.connectorConfig = connectorConfig;
         this.jdbcConnection = jdbcConnection;
         this.schema = schema;
         this.dispatcher = dispatcher;
         this.clock = clock;
-        this.snapshotProgressListener = snapshotProgressListener;
+        this.snapshotProgressListeners = snapshotProgressListeners;
     }
 
     @Override
@@ -104,7 +104,8 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
             // Note that there's a minor race condition here: a new table matching the filters could be created between
             // this call and the determination of the initial snapshot position below; this seems acceptable, though
             determineCapturedTables(ctx);
-            snapshotProgressListener.monitoredDataCollectionsDetermined(snapshotContext.partition, ctx.capturedTables);
+            snapshotProgressListeners
+                    .forEach(snapshotProgressListener -> snapshotProgressListener.monitoredDataCollectionsDetermined(snapshotContext.partition, ctx.capturedTables));
 
             LOGGER.info("Snapshot step 3 - Locking captured tables {}", ctx.capturedTables);
 
@@ -342,7 +343,8 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
         final Optional<String> selectStatement = determineSnapshotSelect(snapshotContext, table.id());
         if (!selectStatement.isPresent()) {
             LOGGER.warn("For table '{}' the select statement was not provided, skipping table", table.id());
-            snapshotProgressListener.dataCollectionSnapshotCompleted(snapshotContext.partition, table.id(), 0);
+            snapshotProgressListeners
+                    .forEach(snapshotProgressListener -> snapshotProgressListener.dataCollectionSnapshotCompleted(snapshotContext.partition, table.id(), 0));
             return;
         }
         LOGGER.info("\t For table '{}' using select statement: '{}'", table.id(), selectStatement.get());
@@ -376,7 +378,10 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                             LOGGER.info("\t Exported {} records for table '{}' after {}", rows, table.id(),
                                     Strings.duration(stop - exportStart));
                         }
-                        snapshotProgressListener.rowsScanned(snapshotContext.partition, table.id(), rows);
+
+                        long finalRows = rows;
+                        snapshotProgressListeners
+                                .forEach(snapshotProgressListener -> snapshotProgressListener.rowsScanned(snapshotContext.partition, table.id(), finalRows));
                         logTimer = getTableScanLogTimer();
                     }
 
@@ -393,7 +398,10 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
             LOGGER.info("\t Finished exporting {} records for table '{}'; total duration '{}'", rows,
                     table.id(), Strings.duration(clock.currentTimeInMillis() - exportStart));
-            snapshotProgressListener.dataCollectionSnapshotCompleted(snapshotContext.partition, table.id(), rows);
+
+            long finalRows = rows;
+            snapshotProgressListeners
+                    .forEach(snapshotProgressListener -> snapshotProgressListener.dataCollectionSnapshotCompleted(snapshotContext.partition, table.id(), finalRows));
         }
         catch (SQLException e) {
             throw new ConnectException("Snapshotting of table " + table.id() + " failed", e);


### PR DESCRIPTION
This change creates two new classes `SqlServerStreamingDatabaseNotifier` and `SqlServerSnapshotDatabaseNotifier` that implement the `SnapshotProgressListener` and the new `StreamingProgressListener` interfaces. These new classes are intended for calling stored procedures or CRUD necessary for notifying the database of snapshot or streaming events as they occur. An example would be when a new capture instance starts being read.