### PR TITLE
[CXP-1523] Call back to the database for streaming and snapshot progress events.

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -43,12 +43,14 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
 
     @Override
     public SnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
-        return new SqlServerSnapshotChangeEventSource(configuration, dataConnection, schema, dispatcher, clock,
-                snapshotProgressListener);
+        return new SqlServerSnapshotChangeEventSource(configuration, dataConnection, schema, dispatcher, clock, snapshotProgressListener);
     }
 
     @Override
     public StreamingChangeEventSource<SqlServerPartition, SqlServerOffsetContext> getStreamingChangeEventSource() {
+        SqlServerStreamingProgressListener streamingProgressListener = configuration.getOptionDatabaseCallbacks()
+                ? new SqlServerStreamingProgressDatabaseCallbacks(dataConnection)
+                : SqlServerStreamingProgressListener.NO_OP;
         return new SqlServerStreamingChangeEventSource(
                 configuration,
                 dataConnection,
@@ -56,7 +58,8 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
                 dispatcher,
                 errorHandler,
                 clock,
-                schema);
+                schema,
+                streamingProgressListener);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -313,6 +313,14 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                     + "In '" + SnapshotIsolationMode.READ_UNCOMMITTED.getValue()
                     + "' mode neither table nor row-level locks are acquired, but connector does not guarantee snapshot consistency.");
 
+    public static final Field DATABASE_CALLBACKS = Field.createInternal("database.callbacks")
+            .withDisplayName("Database Callbacks")
+            .withDefault(false)
+            .withType(Type.BOOLEAN)
+            .withImportance(Importance.LOW)
+            .withValidation(Field::isBoolean)
+            .withDescription("This property can be used to enable/disable performing database callbacks during snapshot or streaming.");
+
     private static final ConfigDefinition CONFIG_DEFINITION = HistorizedRelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .name("SQL Server")
             .type(
@@ -328,7 +336,8 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                     SNAPSHOT_ISOLATION_MODE,
                     SOURCE_TIMESTAMP_MODE,
                     MAX_TRANSACTIONS_PER_ITERATION,
-                    BINARY_HANDLING_MODE)
+                    BINARY_HANDLING_MODE,
+                    DATABASE_CALLBACKS)
             .excluding(
                     SCHEMA_WHITELIST,
                     SCHEMA_INCLUDE_LIST,
@@ -353,6 +362,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     private final boolean readOnlyDatabaseConnection;
     private final int maxTransactionsPerIteration;
     private final boolean multiPartitionMode;
+    private final boolean optionDatabaseCallbacks;
 
     public SqlServerConnectorConfig(Configuration config) {
         super(SqlServerConnector.class, config, config.getString(SERVER_NAME), new SystemTablesPredicate(), x -> x.schema() + "." + x.table(), true,
@@ -393,6 +403,8 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         if (!config.getBoolean(MAX_LSN_OPTIMIZATION)) {
             LOGGER.warn("The option '{}' is no longer taken into account. The optimization is always enabled.", MAX_LSN_OPTIMIZATION.name());
         }
+
+        this.optionDatabaseCallbacks = config.getBoolean(DATABASE_CALLBACKS);
     }
 
     public Configuration jdbcConfig() {
@@ -409,6 +421,10 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
 
     public boolean isMultiPartitionModeEnabled() {
         return multiPartitionMode;
+    }
+
+    public boolean getOptionDatabaseCallbacks() {
+        return optionDatabaseCallbacks;
     }
 
     public SnapshotIsolationMode getSnapshotIsolationMode() {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotProgressDatabaseCallbacks.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotProgressDatabaseCallbacks.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.sql.SQLException;
+
+import io.debezium.DebeziumException;
+import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionId;
+
+/**
+ * A class invoked by {@link SnapshotChangeEventSource} to notify the database of events via stored procedures
+ *
+ * @author Jacob Gminder
+ */
+public class SqlServerSnapshotProgressDatabaseCallbacks implements SnapshotProgressListener {
+    private final SqlServerConnection dataConnection;
+
+    public SqlServerSnapshotProgressDatabaseCallbacks(SqlServerConnection dataConnection) {
+        this.dataConnection = dataConnection;
+    }
+
+    @Override
+    public void snapshotStarted(Partition partition) {
+        try {
+            SqlServerPartition sqlServerPartition = (SqlServerPartition) partition;
+            dataConnection.callbackOnSnapshotStarted(sqlServerPartition);
+        }
+        catch (SQLException exception) {
+            throw new DebeziumException(exception);
+        }
+    }
+
+    @Override
+    public void snapshotCompleted(Partition partition) {
+        try {
+            SqlServerPartition sqlServerPartition = (SqlServerPartition) partition;
+            dataConnection.callbackOnSnapshotCompleted(sqlServerPartition);
+        }
+        catch (SQLException exception) {
+            throw new DebeziumException(exception);
+        }
+    }
+
+    @Override
+    public void snapshotAborted(Partition partition) {
+        try {
+            SqlServerPartition sqlServerPartition = (SqlServerPartition) partition;
+            dataConnection.callbackOnSnapshotAborted(sqlServerPartition);
+        }
+        catch (SQLException exception) {
+            throw new DebeziumException(exception);
+        }
+    }
+
+    @Override
+    public void dataCollectionSnapshotCompleted(Partition partition,
+                                                DataCollectionId dataCollectionId, long numRows) {
+        try {
+            SqlServerPartition sqlServerPartition = (SqlServerPartition) partition;
+            dataConnection.callbackOnDataCollectionSnapshotCompleted(sqlServerPartition, dataCollectionId);
+        }
+        catch (SQLException exception) {
+            throw new DebeziumException(exception);
+        }
+    }
+
+    @Override
+    public void rowsScanned(Partition partition, TableId tableId, long numRows) {
+        // Do nothing
+    }
+
+    @Override
+    public void currentChunk(Partition partition, String chunkId, Object[] chunkFrom,
+                             Object[] chunkTo) {
+        // Do nothing
+    }
+
+    @Override
+    public void currentChunk(Partition partition, String chunkId, Object[] chunkFrom,
+                             Object[] chunkTo, Object[] tableTo) {
+        // Do nothing
+    }
+
+    @Override
+    public void monitoredDataCollectionsDetermined(Partition partition, Iterable iterable) {
+        // Do nothing
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -79,6 +79,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
 
     private final EventDispatcher<TableId> dispatcher;
     private final ErrorHandler errorHandler;
+    private final SqlServerStreamingProgressListener streamingProgressListener;
     private final Clock clock;
     private final SqlServerDatabaseSchema schema;
     private final Duration pollInterval;
@@ -89,12 +90,14 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
 
     public SqlServerStreamingChangeEventSource(SqlServerConnectorConfig connectorConfig, SqlServerConnection dataConnection,
                                                SqlServerConnection metadataConnection, EventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock,
-                                               SqlServerDatabaseSchema schema) {
+                                               SqlServerDatabaseSchema schema,
+                                               SqlServerStreamingProgressListener streamingProgressListener) {
         this.connectorConfig = connectorConfig;
         this.dataConnection = dataConnection;
         this.metadataConnection = metadataConnection;
         this.dispatcher = dispatcher;
         this.errorHandler = errorHandler;
+        this.streamingProgressListener = streamingProgressListener;
         this.clock = clock;
         this.schema = schema;
         this.pollInterval = connectorConfig.getPollInterval();
@@ -331,6 +334,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                 new SqlServerSchemaChangeEventEmitter(partition, offsetContext, newTable, tableSchema,
                         SchemaChangeEventType.ALTER));
         newTable.setSourceTable(tableSchema);
+        streamingProgressListener.onReadingNewChangeTable(partition, newTable);
     }
 
     private SqlServerChangeTable[] processErrorFromChangeTableQuery(String databaseName, SQLException exception,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingProgressDatabaseCallbacks.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingProgressDatabaseCallbacks.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.sql.SQLException;
+
+import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.ChangeTable;
+
+/**
+ * A class invoked by {@link StreamingChangeEventSource} to notify the database of events via stored
+ * procedures
+ *
+ * @author Jacob Gminder
+ */
+public class SqlServerStreamingProgressDatabaseCallbacks implements
+        SqlServerStreamingProgressListener {
+
+    private final SqlServerConnection dataConnection;
+
+    SqlServerStreamingProgressDatabaseCallbacks(final SqlServerConnection dataConnection) {
+        this.dataConnection = dataConnection;
+    }
+
+    public void onReadingNewChangeTable(Partition partition, ChangeTable table) throws SQLException {
+        SqlServerPartition sqlServerPartition = (SqlServerPartition) partition;
+        dataConnection.callbackOnReadingNewChangeTable(sqlServerPartition, table);
+    }
+
+    @Override
+    public void connected(boolean connected) {
+        // Do nothing.
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingProgressListener.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingProgressListener.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.sql.SQLException;
+
+import io.debezium.pipeline.source.spi.StreamingProgressListener;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.ChangeTable;
+
+public interface SqlServerStreamingProgressListener extends StreamingProgressListener {
+    void onReadingNewChangeTable(Partition partition, ChangeTable table) throws SQLException;
+
+    static SqlServerStreamingProgressListener NO_OP = new SqlServerStreamingProgressListener() {
+        @Override
+        public void onReadingNewChangeTable(Partition partition, ChangeTable table) {
+        }
+
+        @Override
+        public void connected(boolean connected) {
+        }
+    };
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotProgressListenerList.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotProgressListenerList.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.spi;
+
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionId;
+
+/**
+ * A list of {@link SnapshotProgressListener}s specific to one database.
+ *
+ * @author Jacob Gminder
+ */
+public class SnapshotProgressListenerList implements SnapshotProgressListener {
+
+    private final Iterable<SnapshotProgressListener> listeners;
+
+    /**
+     * Create a SqlServerSnapshotProgressListenerList to allow iterating over multiple snapshot listeners
+     *
+     * @param listeners
+     *            A list of {@link SnapshotProgressListener} called for changes in the state of snapshot.
+     *
+     */
+    public SnapshotProgressListenerList(Iterable<SnapshotProgressListener> listeners) {
+        if (listeners == null) {
+            throw new IllegalArgumentException("The list of snapshot progress listeners cannot be null.");
+        }
+        this.listeners = listeners;
+    }
+
+    @Override
+    public void snapshotStarted(Partition partition) {
+        listeners.forEach(listener -> listener.snapshotStarted(partition));
+    }
+
+    @Override
+    public void monitoredDataCollectionsDetermined(Partition partition,
+                                                   Iterable<? extends DataCollectionId> dataCollectionIds) {
+        listeners.forEach(listener -> listener.monitoredDataCollectionsDetermined(partition, dataCollectionIds));
+    }
+
+    @Override
+    public void snapshotCompleted(Partition partition) {
+        listeners.forEach(listener -> listener.snapshotCompleted(partition));
+    }
+
+    @Override
+    public void snapshotAborted(Partition partition) {
+        listeners.forEach(listener -> listener.snapshotAborted(partition));
+    }
+
+    @Override
+    public void dataCollectionSnapshotCompleted(Partition partition,
+                                                DataCollectionId dataCollectionId, long numRows) {
+        listeners.forEach(listener -> listener.dataCollectionSnapshotCompleted(partition, dataCollectionId, numRows));
+    }
+
+    @Override
+    public void rowsScanned(Partition partition, TableId tableId, long numRows) {
+        listeners.forEach(listener -> listener.rowsScanned(partition, tableId, numRows));
+    }
+
+    @Override
+    public void currentChunk(Partition partition, String chunkId, Object[] chunkFrom,
+                             Object[] chunkTo) {
+        listeners.forEach(listener -> listener.currentChunk(partition, chunkId, chunkFrom, chunkTo));
+    }
+
+    @Override
+    public void currentChunk(Partition partition, String chunkId, Object[] chunkFrom,
+                             Object[] chunkTo, Object[] tableTo) {
+        listeners.forEach(listener -> listener.currentChunk(partition, chunkId, chunkFrom, chunkTo, tableTo));
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingProgressListener.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingProgressListener.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.spi;
+
+/**
+ * Invoked whenever an important event or change of state happens during the streaming phase.
+ */
+public interface StreamingProgressListener {
+
+    void connected(boolean connected);
+}


### PR DESCRIPTION
This change creates two new classes `SqlServerStreamingProgressDatabaseCallbacks` and `SqlServerSnapshotProgressDatabaseCallbacks` that implement the `SnapshotProgressListener` and the new `StreamingProgressListener` and `SqlServerStreamingProgressListener` interfaces. These new classes are intended for calling stored procedures or CRUD necessary for calling back to the database during snapshot or streaming events as they occur. An example would be when a new capture instance starts being read.