### PR TITLE
[CXP-1523] Call back to the database for snapshot progress events.

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -575,33 +575,33 @@ public class SqlServerConnection extends JdbcConnection {
     public void callbackOnReadingNewChangeTable(SqlServerPartition partition, ChangeTable table) throws SQLException {
         final String query = replaceDatabaseNamePlaceholder(START_READING_CHANGE_TABLE, partition.getDatabaseName());
         prepareUpdate(query, ps -> {
-            LOGGER.trace("Calling the StartReadingFromCaptureInstance stored procedure with change table: {}", table);
+            LOGGER.debug("Calling the StartReadingFromCaptureInstance stored procedure with change table: {}", table);
             ps.setString(1, table.getCaptureInstance());
         });
     }
 
     public void callbackOnSnapshotStarted(SqlServerPartition partition) throws SQLException {
         final String statement = replaceDatabaseNamePlaceholder(START_SNAPSHOT, partition.getDatabaseName());
-        LOGGER.trace("Calling the StartSnapshot stored procedure");
+        LOGGER.debug("Calling the StartSnapshot stored procedure");
         execute(statement);
     }
 
     public void callbackOnSnapshotCompleted(SqlServerPartition partition) throws SQLException {
         final String statement = replaceDatabaseNamePlaceholder(COMPLETED_SNAPSHOT, partition.getDatabaseName());
-        LOGGER.trace("Calling the CompletedSnapshot stored procedure");
+        LOGGER.debug("Calling the CompletedSnapshot stored procedure");
         execute(statement);
     }
 
     public void callbackOnSnapshotAborted(SqlServerPartition partition) throws SQLException {
         final String statement = replaceDatabaseNamePlaceholder(ABORTED_SNAPSHOT, partition.getDatabaseName());
-        LOGGER.trace("Calling the CompletedSnapshot stored procedure");
+        LOGGER.debug("Calling the CompletedSnapshot stored procedure");
         execute(statement);
     }
 
     public void callbackOnDataCollectionSnapshotCompleted(SqlServerPartition partition, DataCollectionId dataCollectionId) throws SQLException {
         final String query = replaceDatabaseNamePlaceholder(DATA_COLLECTION_SNAPSHOT_COMPLETED, partition.getDatabaseName());
         prepareUpdate(query, ps -> {
-            LOGGER.trace("Calling the DataCollectionSnapshotCompleted stored procedure with dataCollectionId: {}", dataCollectionId);
+            LOGGER.debug("Calling the DataCollectionSnapshotCompleted stored procedure with dataCollectionId: {}", dataCollectionId);
             ps.setString(1, dataCollectionId.identifier());
         });
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -313,7 +313,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                     + "In '" + SnapshotIsolationMode.READ_UNCOMMITTED.getValue()
                     + "' mode neither table nor row-level locks are acquired, but connector does not guarantee snapshot consistency.");
 
-    public static final Field DATABASE_CALLBACKS = Field.createInternal("database.callbacks")
+    public static final Field DATABASE_CALLBACKS = Field.create("database.callbacks")
             .withDisplayName("Database Callbacks")
             .withDefault(false)
             .withType(Type.BOOLEAN)
@@ -405,6 +405,12 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         }
 
         this.optionDatabaseCallbacks = config.getBoolean(DATABASE_CALLBACKS);
+        if (optionDatabaseCallbacks) {
+            LOGGER.info("Database callbacks are enabled");
+        }
+        else {
+            LOGGER.info("Database callbacks are disabled");
+        }
     }
 
     public Configuration jdbcConfig() {


### PR DESCRIPTION
Change the `database.callbacks` option to a non-internal configuration parameter and increase the log level for the database callbacks.