### PR TITLE
CXP-1795: Ignore column lengths that don't fit in 32 bits

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/ColumnDefinitionParserListener.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/ColumnDefinitionParserListener.java
@@ -151,8 +151,13 @@ public class ColumnDefinitionParserListener extends MySqlParserBaseListener {
             MySqlParser.StringDataTypeContext stringDataTypeContext = (MySqlParser.StringDataTypeContext) dataTypeContext;
 
             if (stringDataTypeContext.lengthOneDimension() != null) {
-                Integer length = Integer.valueOf(stringDataTypeContext.lengthOneDimension().decimalLiteral().getText());
-                columnEditor.length(length);
+                try {
+                    Integer length = Integer.valueOf(stringDataTypeContext.lengthOneDimension().decimalLiteral().getText());
+                    columnEditor.length(length);
+                }
+                catch (NumberFormatException e) {
+                    // ignore lengths that don't fit into 32 bits
+                }
             }
 
             charsetName = parser.extractCharset(stringDataTypeContext.charsetName(), stringDataTypeContext.collationName());

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -2900,6 +2900,15 @@ public class MySqlAntlrDdlParserTest {
         assertThat(table.columnWithName("ts_col").defaultValue()).isEqualTo(toIsoString("2020-01-02 03:04:05"));
     }
 
+    @Test
+    public void shouldIgnoreColumnLengthOver32Bits() {
+        parser.parse("CREATE TABLE table1(id INT);", tables);
+        parser.parse("ALTER TABLE table1 add COLUMN text1 text(4294967295)  NULL", tables);
+
+        Table table = tables.forTable(new TableId(null, null, "table1"));
+        assertThat(table.columnWithName("text1").length()).isEqualTo(Column.UNSET_INT_VALUE);
+    }
+
     private String toIsoString(String timestamp) {
         return ZonedTimestamp.toIsoString(Timestamp.valueOf(timestamp).toInstant().atZone(ZoneId.systemDefault()), null);
     }


### PR DESCRIPTION
The failure is caused by such DDL: `ALTER TABLE table1 add COLUMN text1 text(4294967295)  NULL`. Here  the column length when parsed doesn't fit to 32 bits of signed integer.

I tried to change the variable type that stores the column length from `int` to `long` but it required a lot of changes across `debezium-core` many of which were not trivial and were not safe to do without thorough understanding of the code being changed.

As a hot fix ignoring column lengths that don't fit in 32 bits should be enough.