### PR TITLE
DBZ-5033: Ignore null offsets when recovering database history

### DIFF
--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -59,6 +59,7 @@ import io.debezium.relational.history.FileDatabaseHistory;
 import io.debezium.relational.history.HistoryRecordComparator;
 import io.debezium.relational.history.TableChanges;
 import io.debezium.schema.DatabaseSchema;
+import io.debezium.util.Collect;
 import io.debezium.util.Testing;
 
 /**
@@ -2750,6 +2751,27 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
             // https://docs.microsoft.com/en-us/sql/t-sql/statements/drop-database-transact-sql?view=sql-server-ver15#general-remarks
             connection.execute("ALTER DATABASE " + TestHelper.TEST_DATABASE2 + " SET ONLINE");
         }
+    }
+
+    @Test
+    @FixFor("DBZ-5033")
+    public void shouldIgnoreNullOffsetsWhenRecoveringHistory() {
+        final Configuration config1 = TestHelper.defaultMultiDatabaseConfig(
+                Collections.singletonList(TestHelper.TEST_DATABASE1))
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY)
+                .build();
+        start(SqlServerConnector.class, config1);
+        assertConnectorIsRunning();
+        TestHelper.waitForSnapshotToBeCompleted(TestHelper.TEST_REAL_DATABASE1);
+        stopConnector();
+
+        final Configuration config2 = TestHelper.defaultMultiDatabaseConfig(
+                Collect.arrayListOf(TestHelper.TEST_DATABASE1, TestHelper.TEST_DATABASE2))
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .build();
+        start(SqlServerConnector.class, config2);
+        assertConnectorIsRunning();
+        stopConnector();
     }
 
     private void assertRecord(Struct record, List<SchemaAndValueField> expected) {

--- a/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
@@ -24,8 +24,8 @@ import io.debezium.relational.ddl.DdlParser;
 
 /**
  * A history of the database schema described by a {@link Tables}. Changes to the database schema can be
- * {@link #record(Map, Map, String, Tables, String) recorded}, and a {@link Tables database schema} can be
- * {@link #record(Map, Map, String, Tables, String) recovered} to various points in that history.
+ * {@link #record(Map, Map, String, String) recorded}, and a {@link Tables database schema} can be
+ * {@link #record(Map, Map, String, String) recovered} to various points in that history.
  *
  * @author Randall Hauch
  */
@@ -139,7 +139,7 @@ public interface DatabaseHistory {
 
     /**
      * Recover the {@link Tables database schema} to a known point in its history. Note that it is possible to recover the
-     * database schema to a point in history that is earlier than what has been {@link #record(Map, Map, String, Tables, String)
+     * database schema to a point in history that is earlier than what has been {@link #record(Map, Map, String, String)
      * recorded}. Likewise, when recovering to a point in history <em>later</em> than what was recorded, the database schema will
      * reflect the latest state known to the history.
      *
@@ -165,7 +165,7 @@ public interface DatabaseHistory {
     void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser);
 
     /**
-     * Stop recording history and release any resources acquired since {@link #configure(Configuration, HistoryRecordComparator, DatabaseHistoryListener)}.
+     * Stop recording history and release any resources acquired since {@link #configure(Configuration, HistoryRecordComparator, DatabaseHistoryListener, boolean)}.
      */
     void stop();
 

--- a/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
@@ -19,6 +19,7 @@ import io.debezium.config.Field;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.HistorizedRelationalDatabaseSchema;
 import io.debezium.relational.Tables;
 import io.debezium.relational.ddl.DdlParser;
 
@@ -144,7 +145,8 @@ public interface DatabaseHistory {
      * reflect the latest state known to the history.
      *
      * @param offsets the map of information about the source database to corresponding point in history at which database
-     *                schema should be recovered
+     *                schema should be recovered; should contain at least one non-null offset
+     *                which is enforced in {@link HistorizedRelationalDatabaseSchema#recover(Offsets)}
      * @param schema the table definitions that should be changed to reflect the database schema at the desired point in history;
      *            may not be null
      * @param ddlParser the DDL parser that can be used to apply DDL statements to the given {@code schema}; may not be null
@@ -152,7 +154,9 @@ public interface DatabaseHistory {
     default void recover(Offsets<?, ?> offsets, Tables schema, DdlParser ddlParser) {
         Map<Map<String, ?>, Map<String, ?>> offsetMap = new HashMap<>();
         for (Entry<? extends Partition, ? extends OffsetContext> entry : offsets) {
-            offsetMap.put(entry.getKey().getSourcePartition(), entry.getValue().getOffset());
+            if (entry.getValue() != null) {
+                offsetMap.put(entry.getKey().getSourcePartition(), entry.getValue().getOffset());
+            }
         }
 
         recover(offsetMap, schema, ddlParser);


### PR DESCRIPTION
This is a backport of https://github.com/debezium/debezium/pull/3425.