### PR TITLE
CXP-2071: [SPIKE] Refactor schema change handling callbacks to use committed offsets

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -104,6 +104,7 @@ public class SqlServerConnection extends JdbcConnection {
     private static final String GET_NEW_CHANGE_TABLES = "SELECT * FROM [#db].cdc.change_tables WHERE start_lsn BETWEEN ? AND ?";
     private static final String OPENING_QUOTING_CHARACTER = "[";
     private static final String CLOSING_QUOTING_CHARACTER = "]";
+    private static final String DELETE_CHANGE_TABLE = "EXEC [#db].dbo.DebeziumSQLConnector_DeleteCaptureInstance @CaptureInstanceName = ?";
 
     private static final String URL_PATTERN = "jdbc:sqlserver://${" + JdbcConfiguration.HOSTNAME + "}:${" + JdbcConfiguration.PORT + "}";
 
@@ -611,5 +612,13 @@ public class SqlServerConnection extends JdbcConnection {
 
     public SqlServerDefaultValueConverter getDefaultValueConverter() {
         return defaultValueConverter;
+    }
+
+    public void deleteChangeTable(String databaseName, SqlServerChangeTable table) throws SQLException {
+        final String query = replaceDatabaseNamePlaceholder(DELETE_CHANGE_TABLE, databaseName);
+        prepareUpdate(query, ps -> {
+            LOGGER.trace("Calling the DeleteCaptureInstance stored procedure with change table: {}", table);
+            ps.setString(1, table.getCaptureInstance());
+        });
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +106,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                         ? DEFAULT_INTERVAL_BETWEEN_COMMITS.toMillis()
                         : intervalBetweenCommitsBasedOnPoll.toMillis());
         this.pauseBetweenCommits.hasElapsed();
-        this.streamingExecutionContexts = new HashMap<>();
+        this.streamingExecutionContexts = Collections.synchronizedMap(new HashMap<>());
     }
 
     @Override
@@ -144,6 +145,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             final TxLogPosition lastProcessedPositionOnStart = offsetContext.getChangePosition();
             final long lastProcessedEventSerialNoOnStart = offsetContext.getEventSerialNo();
             final AtomicBoolean changesStoppedBeingMonotonic = streamingExecutionContext.getChangesStoppedBeingMonotonic();
+            final List<SqlServerChangeTable> changeTablesWithKnownStopLsn = streamingExecutionContext.getChangeTablesWithKnownStopLsn();
             final int maxTransactionsPerIteration = connectorConfig.getMaxTransactionsPerIteration();
 
             TxLogPosition lastProcessedPosition = streamingExecutionContext.getLastProcessedPosition();
@@ -180,6 +182,13 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                         if (table.getStartLsn().isBetween(fromLsn, toLsn)) {
                             LOGGER.info("Schema will be changed for {}", table);
                             schemaChangeCheckpoints.add(table);
+                        }
+                    }
+
+                    for (SqlServerChangeTable table : tables) {
+                        if (table.getStopLsn().isAvailable()) {
+                            LOGGER.info("The stop lsn of {} change table became known", table);
+                            changeTablesWithKnownStopLsn.add(table);
                         }
                     }
                 }
@@ -446,5 +455,35 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
         }
 
         return connection.getNthTransactionLsnFromLast(databaseName, fromLsn, maxTransactionsPerIteration);
+    }
+
+    @Override
+    public void commitOffset(Map<String, ?> offset) {
+        Lsn commitLsn = Lsn.valueOf((String) offset.get("commit_lsn"));
+        synchronized (streamingExecutionContexts) {
+            for (Map.Entry<SqlServerPartition, SqlServerStreamingExecutionContext> entry : streamingExecutionContexts.entrySet()) {
+                SqlServerPartition partition = entry.getKey();
+                List<SqlServerChangeTable> changeTablesWithKnownStopLsn = entry.getValue().getChangeTablesWithKnownStopLsn();
+
+                synchronized (changeTablesWithKnownStopLsn) {
+                    List<SqlServerChangeTable> changeTablesToBeDeleted = changeTablesWithKnownStopLsn.stream()
+                            .filter(t -> t.getStopLsn().compareTo(commitLsn) < 0)
+                            .collect(Collectors.toList());
+
+                    for (SqlServerChangeTable table : changeTablesToBeDeleted) {
+                        try {
+                            dataConnection.deleteChangeTable(partition.getDatabaseName(), table);
+                        }
+                        catch (SQLException e) {
+                            throw new RuntimeException(e);
+                        }
+                        LOGGER.info("Deleted change table {} as the committed change lsn ({}) is greater than the table's stop lsn", table, offset);
+
+                    }
+
+                    changeTablesWithKnownStopLsn.removeAll(changeTablesToBeDeleted);
+                }
+            }
+        }
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingExecutionContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingExecutionContext.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.connector.sqlserver;
 
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -22,6 +25,7 @@ public class SqlServerStreamingExecutionContext {
     private TxLogPosition lastProcessedPosition;
     private final AtomicBoolean changesStoppedBeingMonotonic;
     private boolean shouldIncreaseFromLsn;
+    private final List<SqlServerChangeTable> changeTablesWithKnownStopLsn = Collections.synchronizedList(new LinkedList<>());
 
     public SqlServerStreamingExecutionContext(PriorityQueue<SqlServerChangeTable> schemaChangeCheckpoints, AtomicReference<SqlServerChangeTable[]> tablesSlot,
                                               TxLogPosition changePosition, AtomicBoolean changesStoppedBeingMonotonic, boolean snapshotCompleted) {
@@ -58,5 +62,9 @@ public class SqlServerStreamingExecutionContext {
 
     public boolean getShouldIncreaseFromLsn() {
         return shouldIncreaseFromLsn;
+    }
+
+    public List<SqlServerChangeTable> getChangeTablesWithKnownStopLsn() {
+        return changeTablesWithKnownStopLsn;
     }
 }


### PR DESCRIPTION
The previous version of the feature was tracked in [sugarcrm-jgminder/1.9.2-database-callbacks](https://github.com/sugarcrm-jgminder/debezium/tree/1.9.2-database-callbacks).

TODO:
- [x] Create a feature branch in the SugarCRM's fork (`database-callbacks`), and retarget from the production branch.
- [ ] Fix the existing test failures.
- [x] ~~Add more tests~~ (CXP-2157).
- [x] ~~Make sure that this feature can be disabled via configuration~~ (CXP-2156).