### PR TITLE
CXP-2278: Handle another SQL Server error as retriable

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
@@ -37,6 +37,7 @@ public class SqlServerErrorHandler extends ErrorHandler {
                         || throwable.getMessage().contains("Try the statement later.")
                         || throwable.getMessage().contains("Connection reset")
                         || throwable.getMessage().contains("Socket closed")
+                        || throwable.getMessage().contains("Cannot continue the execution because the session is in the kill state.")
                         || throwable.getMessage().contains("SHUTDOWN is in progress")
                         || throwable.getMessage().contains("The server failed to resume the transaction")
                         || throwable.getMessage().contains("Verify the connection properties")


### PR DESCRIPTION
Before this is merged, the following patches have been [applied](https://sugarcrm.slack.com/archives/C01AELD28BT/p1666825793083489?thread_ts=1666775819.052149&cid=C01AELD28BT) to the connectors:
```shell
kubectl --context k8s-usw2-prod -n cxp patch kctr market.use1-mssql-01 \
--type=json \
-p '[{
    "op":"add",
    "path":"/spec/config/custom.retriable.exception",
    "value":"Cannot continue the execution because the session is in the kill state\\."
}]'

kubectl --context k8s-usw2-prod -n cxp patch kctr market.use1-mssql-03 \
--type=json \
-p '[{
    "op":"add",
    "path":"/spec/config/custom.retriable.exception",
    "value":"Cannot continue the execution because the session is in the kill state\\."
}]'
```