### PR TITLE
DBZ-5855: IllegalStateException is thrown if task is recovering while other tasks are running

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -363,14 +363,6 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
         Map<TopicPartition, Long> offsets = historyConsumer.endOffsets(Collections.singleton(new TopicPartition(topicName, PARTITION)));
         Long endOffset = offsets.entrySet().iterator().next().getValue();
 
-        // The end offset should never change during recovery; doing this check here just as - a rather weak - attempt
-        // to spot other connectors that share the same history topic accidentally
-        if (previousEndOffset != null && !previousEndOffset.equals(endOffset)) {
-            throw new IllegalStateException("Detected changed end offset of database history topic (previous: "
-                    + previousEndOffset + ", current: " + endOffset
-                    + "). Make sure that the same history topic isn't shared by multiple connector instances.");
-        }
-
         return endOffset;
     }
 


### PR DESCRIPTION
JIRA: [DBZ-5855](https://issues.redhat.com/browse/DBZ-5855)
**TODO:**
- [x] remove condition throwing `IllegalStateException`