### PR TITLE
CXP-2371: [SPIKE] Test schema change database callbacks against real …

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -99,7 +99,7 @@ public class SqlServerConnection extends JdbcConnection {
     private static final String GET_NEW_CHANGE_TABLES = "SELECT * FROM [#db].cdc.change_tables WHERE start_lsn BETWEEN ? AND ?";
     private static final String OPENING_QUOTING_CHARACTER = "[";
     private static final String CLOSING_QUOTING_CHARACTER = "]";
-    private static final String COMPLETE_READING_FROM_CAPTURE_INSTANCE = "EXEC [#db].dbo.DebeziumSQLConnector_CompletedReadingFromCaptureInstance @CaptureInstanceName = ?, @StartLSN = ?, @StopLSN = ?, @ChangeTableName = ?";
+    private static final String COMPLETE_READING_FROM_CAPTURE_INSTANCE = "EXEC [#db].dbo.DebeziumSQLConnector_CompletedReadingFromCaptureInstance @CaptureInstanceName = ?, @StartLSN = ?, @StopLSN = ?";
 
     private static final String URL_PATTERN = "jdbc:sqlserver://${" + JdbcConfiguration.HOSTNAME + "}:${" + JdbcConfiguration.PORT + "}";
 
@@ -653,7 +653,6 @@ public class SqlServerConnection extends JdbcConnection {
             ps.setString(1, table.getCaptureInstance());
             ps.setString(2, table.getStartLsn().toString());
             ps.setString(3, table.getStopLsn().toString());
-            ps.setString(4, table.getChangeTableId().table());
         });
     }
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/DatabaseCallbacksIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/DatabaseCallbacksIT.java
@@ -144,7 +144,6 @@ public class DatabaseCallbacksIT extends AbstractConnectorTest {
                 "(@CaptureInstanceName sysname,\n" +
                 "@StartLSN varchar(100),\n" +
                 "@StopLSN varchar(100),\n" +
-                "@ChangeTableName sysname,\n" +
                 "@Debug bit = NULL\n" +
                 ") AS BEGIN\n" +
                 "    DECLARE @source_schema sysname;\n" +


### PR DESCRIPTION
…procedures

Removing `@ChangeTableName` from the list of parameters of the stored procedure call as it doesn't exist in dev sqlserver's implementation of the procedure.