### PR TITLE
CXP-2351: Test restart due to streaming failure

### DIFF
--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -2610,10 +2610,26 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
-    public void shouldStopRetriableRestartsAtConfiguredMaximum() throws Exception {
+    public void shouldStopRetriableRestartsAtConfiguredMaximumDuringSnapshot() throws Exception {
+        shouldStopRetriableRestartsAtConfiguredMaximum(() -> {
+            connection.execute("ALTER DATABASE " + TestHelper.TEST_DATABASE_2 + " SET OFFLINE");
+            TestHelper.waitForDatabaseSnapshotToBeCompleted(TestHelper.TEST_DATABASE_1);
+        });
+    }
+
+    @Test
+    public void shouldStopRetriableRestartsAtConfiguredMaximumDuringStreaming() throws Exception {
+        shouldStopRetriableRestartsAtConfiguredMaximum(() -> {
+            TestHelper.waitForStreamingStarted();
+            connection.execute("ALTER DATABASE " + TestHelper.TEST_DATABASE_2
+                    + " SET OFFLINE WITH ROLLBACK IMMEDIATE");
+        });
+    }
+
+    private void shouldStopRetriableRestartsAtConfiguredMaximum(SqlRunnable scenario) throws Exception {
         TestHelper.createTestDatabases(TestHelper.TEST_DATABASE_1, TestHelper.TEST_DATABASE_2);
         final Configuration config1 = TestHelper.defaultConnectorConfig()
-                .with(SqlServerConnectorConfig.DATABASE_NAMES.name(), TestHelper.TEST_DATABASE_1 + "," + TestHelper.TEST_DATABASE_2 + ",non-existing-database")
+                .with(SqlServerConnectorConfig.DATABASE_NAMES.name(), TestHelper.TEST_DATABASE_1 + "," + TestHelper.TEST_DATABASE_2)
                 .with("retriable.restart.connector.max.num", 1)
                 .build();
         final LogInterceptor logInterceptor = new LogInterceptor(BaseSourceTask.class);
@@ -2621,8 +2637,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         try {
             start(SqlServerConnector.class, config1);
             assertConnectorIsRunning();
-            connection.execute("ALTER DATABASE " + TestHelper.TEST_DATABASE_2 + " SET OFFLINE");
-            TestHelper.waitForDatabaseSnapshotToBeCompleted(TestHelper.TEST_DATABASE_1);
+            scenario.run();
 
             final String message1 = "1 of 1 retriable restarts will be attempted";
             final String message2 = "The maximum number of retriable restarts: 1 has been attempted";
@@ -2716,5 +2731,10 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         public boolean skipUnparseableDdlStatements() {
             return false;
         }
+    }
+
+    @FunctionalInterface
+    interface SqlRunnable {
+        void run() throws SQLException;
     }
 }


### PR DESCRIPTION
The problem of permanent errors scoped to a single database blocking capturing changes from others existed only prior to https://github.com/sugarcrm/debezium/pull/133 since the task would restart infinitely and never reach the databases after the one causing the failure.

The logic implemented there behaves as expected and increases the restart counter during each failure unless at least one streaming iteration was successfully completed for _all_ databases processed by the task before the failure. It wasn't obvious to me at the time of filing the issue.

This PR extends the previously added test to cover both the snapshotting failure and streaming failure scenarios. It also removes the "non-existing-database" database from the test configuration as it seems copied from another test and is irrelevant to this one.