### PR TITLE
CXP-2452: Commit the transaction right after a capture instance deletion

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -525,6 +525,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             for (SqlServerChangeTable table : changeTablesToBeDeleted) {
                 try {
                     metadataConnection.completeReadingFromCaptureInstance(partition.getDatabaseName(), table);
+                    metadataConnection.commit();
                 }
                 catch (SQLException e) {
                     throw new RuntimeException(e);


### PR DESCRIPTION
To prevent deadlock exceptions the transaction needs to be committed to release locks as soon as possible:
```
[2023-02-27 15:57:03,484] ERROR [debezium-connector-sqlserver|task-0] Producer failure (io.debezium.pipeline.ErrorHandler:38)
com.microsoft.sqlserver.jdbc.SQLServerException: Transaction (Process ID 454) was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction.
	at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDatabaseError(SQLServerException.java:265)
	at com.microsoft.sqlserver.jdbc.SQLServerResultSet$FetchBuffer.nextRow(SQLServerResultSet.java:5479)
	at com.microsoft.sqlserver.jdbc.SQLServerResultSet.fetchBufferNext(SQLServerResultSet.java:1798)
	at com.microsoft.sqlserver.jdbc.SQLServerResultSet.next(SQLServerResultSet.java:1056)
	at io.debezium.pipeline.source.spi.ChangeTableResultSet.next(ChangeTableResultSet.java:63)
	at io.debezium.connector.sqlserver.SqlServerStreamingChangeEventSource.lambda$executeIteration$3(SqlServerStreamingChangeEventSource.java:232)
	at io.debezium.jdbc.JdbcConnection.prepareQuery(JdbcConnection.java:590)
	at io.debezium.connector.sqlserver.SqlServerConnection.getChangesForTables(SqlServerConnection.java:349)
	at io.debezium.connector.sqlserver.SqlServerStreamingChangeEventSource.executeIteration(SqlServerStreamingChangeEventSource.java:223)
	at io.debezium.connector.sqlserver.SqlServerStreamingChangeEventSource.executeIteration(SqlServerStreamingChangeEventSource.java:63)
	at io.debezium.connector.sqlserver.SqlServerChangeEventSourceCoordinator.executeChangeEventSources(SqlServerChangeEventSourceCoordinator.java:98)
	at io.debezium.pipeline.ChangeEventSourceCoordinator.lambda$start$0(ChangeEventSourceCoordinator.java:111)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```