### PR TITLE
CXP-1742: Merge sqlserver database callbacks

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -101,6 +101,7 @@ public class SqlServerConnection extends JdbcConnection {
     private static final String GET_NEW_CHANGE_TABLES = "SELECT * FROM [#db].cdc.change_tables WHERE start_lsn BETWEEN ? AND ?";
     private static final String OPENING_QUOTING_CHARACTER = "[";
     private static final String CLOSING_QUOTING_CHARACTER = "]";
+    private static final String COMPLETE_READING_FROM_CAPTURE_INSTANCE = "EXEC [#db].dbo.DebeziumSQLConnector_CompletedReadingFromCaptureInstance @CaptureInstanceName = ?, @StartLSN = ?, @StopLSN = ?";
 
     private static final String URL_PATTERN = "jdbc:sqlserver://${" + JdbcConfiguration.HOSTNAME + "}";
 
@@ -629,5 +630,15 @@ public class SqlServerConnection extends JdbcConnection {
     public Optional<Instant> getCurrentTimestamp() throws SQLException {
         return queryAndMap("SELECT SYSDATETIMEOFFSET()",
                 rs -> rs.next() ? Optional.of(rs.getObject(1, OffsetDateTime.class).toInstant()) : Optional.empty());
+    }
+
+    public void completeReadingFromCaptureInstance(String databaseName, SqlServerChangeTable table) throws SQLException {
+        final String query = replaceDatabaseNamePlaceholder(COMPLETE_READING_FROM_CAPTURE_INSTANCE, databaseName);
+        prepareUpdate(query, ps -> {
+            LOGGER.trace("Calling CompletedReadingFromCaptureInstance stored procedure with change table: {}", table);
+            ps.setString(1, table.getCaptureInstance());
+            ps.setString(2, table.getStartLsn().toString());
+            ps.setString(3, table.getStopLsn().toString());
+        });
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -303,6 +303,14 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     public static final Field SOURCE_INFO_STRUCT_MAKER = CommonConnectorConfig.SOURCE_INFO_STRUCT_MAKER
             .withDefault(SqlServerSourceInfoStructMaker.class.getName());
 
+    public static final Field DATABASE_CALLBACKS = Field.create("database.callbacks")
+            .withDisplayName("Database Callbacks")
+            .withDefault(false)
+            .withType(Type.BOOLEAN)
+            .withImportance(Importance.LOW)
+            .withValidation(Field::isBoolean)
+            .withDescription("This property can be used to enable/disable performing database callbacks during snapshot or streaming.");
+
     private static final ConfigDefinition CONFIG_DEFINITION = HistorizedRelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .name("SQL Server")
             .type(
@@ -316,6 +324,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                     SNAPSHOT_MODE,
                     SNAPSHOT_ISOLATION_MODE,
                     MAX_TRANSACTIONS_PER_ITERATION,
+                    DATABASE_CALLBACKS,
                     BINARY_HANDLING_MODE,
                     SCHEMA_NAME_ADJUSTMENT_MODE,
                     INCREMENTAL_SNAPSHOT_OPTION_RECOMPILE,
@@ -346,6 +355,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     private final int maxTransactionsPerIteration;
     private final boolean optionRecompile;
     private final int queryFetchSize;
+    private final boolean optionDatabaseCallbacks;
 
     public SqlServerConnectorConfig(Configuration config) {
         super(
@@ -386,6 +396,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         }
 
         this.optionRecompile = config.getBoolean(INCREMENTAL_SNAPSHOT_OPTION_RECOMPILE);
+        this.optionDatabaseCallbacks = config.getBoolean(DATABASE_CALLBACKS);
     }
 
     public List<String> getDatabaseNames() {
@@ -419,6 +430,10 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
 
     public SnapshotIsolationMode getSnapshotIsolationMode() {
         return this.snapshotIsolationMode;
+    }
+
+    public boolean getOptionDatabaseCallbacks() {
+        return optionDatabaseCallbacks;
     }
 
     public SnapshotMode getSnapshotMode() {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/DatabaseCallbacksIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/DatabaseCallbacksIT.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.sqlserver.util.TestHelper;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.relational.ChangeTable;
+import io.debezium.util.Testing;
+
+public class DatabaseCallbacksIT extends AbstractConnectorTest {
+    private SqlServerConnection connection;
+
+    @Before
+    public void before() throws SQLException {
+        TestHelper.createTestDatabase();
+        connection = TestHelper.testConnection();
+        connection.execute("CREATE TABLE tablea (id int primary key, cola varchar(30))");
+        TestHelper.enableTableCdc(connection, "tablea", "tablea_c1");
+        createDeleteCaptureInstanceProcedure();
+        initializeConnectorTestFramework();
+        Testing.Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
+    }
+
+    @After
+    public void after() throws SQLException {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void testDeleteCaptureInstanceCalledOnCommit() throws InterruptedException, SQLException {
+        final Configuration config = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.DATABASE_CALLBACKS, true)
+                .build();
+
+        start(SqlServerConnector.class, config);
+        assertConnectorIsRunning();
+        TestHelper.waitForStreamingStarted();
+
+        connection.execute("INSERT INTO tablea VALUES(1, 'a')");
+        assertEquals(1, consumeRecords(1));
+
+        connection.execute("ALTER TABLE tablea ADD colb int NULL");
+        TestHelper.enableTableCdc(connection, "tablea", "tablea_c2");
+        connection.execute("INSERT INTO tablea VALUES(2, 'b', 2)");
+        assertEquals(1, consumeRecords(1));
+        waitForChangeTableToBeGone("tablea_c1");
+
+        connection.execute("ALTER TABLE tablea ADD colc int NULL");
+        TestHelper.enableTableCdc(connection, "tablea", "tablea_c3");
+        connection.execute("INSERT INTO tablea VALUES(3, 'b', 3, 4)");
+        assertEquals(1, consumeRecords(1));
+        waitForChangeTableToBeGone("tablea_c2");
+
+        stopConnector();
+    }
+
+    @Test
+    public void testDeleteCaptureInstanceFailsOnCommit() throws InterruptedException, SQLException, TimeoutException {
+        final Configuration config = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.DATABASE_CALLBACKS, true)
+                .build();
+
+        start(SqlServerConnector.class, config, (boolean success, String message, Throwable error) -> {
+            assertFalse(success);
+            assertTrue(message.contains("Could not find stored procedure"));
+            assertNotNull(error);
+        });
+
+        assertConnectorIsRunning();
+        TestHelper.waitForStreamingStarted();
+
+        dropCompletedReadingFromCaptureInstanceProcedure();
+
+        connection.execute("INSERT INTO tablea VALUES(1, 'a')");
+        assertEquals(1, consumeRecords(1));
+
+        connection.execute("ALTER TABLE tablea ADD colb int NULL");
+        TestHelper.enableTableCdc(connection, "tablea", "tablea_c2");
+        connection.execute("INSERT INTO tablea VALUES(2, 'b', 2)");
+        assertEquals(1, consumeRecords(1));
+
+        waitForEngineToStop();
+        stopConnector();
+
+        assertTrue(existingChangeTableNames().contains("tablea_c1"));
+
+        createDeleteCaptureInstanceProcedure();
+
+        start(SqlServerConnector.class, config, (boolean success, String message, Throwable error) -> {
+            assertTrue(success);
+            assertTrue(message.isEmpty());
+            assertNull(error);
+        });
+        assertConnectorIsRunning();
+        TestHelper.waitForStreamingStarted();
+
+        connection.execute("INSERT INTO tablea VALUES(3, 'b', 3)");
+        assertEquals(1, consumeRecords(1));
+        waitForChangeTableToBeGone("tablea_c1");
+
+        connection.execute("INSERT INTO tablea VALUES(4, 'b', 4)");
+        assertEquals(1, consumeRecords(1));
+
+        stopConnector();
+    }
+
+    private void waitForChangeTableToBeGone(String name) {
+        Awaitility.await("Awaiting " + name + " change table to be gone")
+                .atMost(Duration.ofMinutes(5))
+                .until(() -> !existingChangeTableNames().contains(name));
+    }
+
+    private void waitForEngineToStop() {
+        Awaitility.await("Awaiting for the engine to stop")
+                .atMost(Duration.ofMinutes(5))
+                .until(() -> !engine.isRunning());
+    }
+
+    private void createDeleteCaptureInstanceProcedure() throws SQLException {
+        connection.execute("CREATE OR ALTER PROCEDURE dbo.DebeziumSQLConnector_CompletedReadingFromCaptureInstance\n" +
+                "(@CaptureInstanceName sysname,\n" +
+                "@StartLSN varchar(100),\n" +
+                "@StopLSN varchar(100),\n" +
+                "@Debug bit = NULL\n" +
+                ") AS BEGIN\n" +
+                "    DECLARE @source_schema sysname;\n" +
+                "    DECLARE @source_name sysname;\n" +
+                "\n" +
+                "    SELECT \n" +
+                "        @source_schema = OBJECT_SCHEMA_NAME(ct.source_object_id),\n" +
+                "        @source_name = OBJECT_NAME(ct.source_object_id)\n" +
+                "    FROM cdc.change_tables ct \n" +
+                "    WHERE ct.capture_instance = @CaptureInstanceName;\n" +
+                "\n" +
+                "    EXEC sys.sp_cdc_disable_table \n" +
+                "        @source_schema = @source_schema, \n" +
+                "        @source_name = @source_name, \n" +
+                "        @capture_instance = @CaptureInstanceName\n" +
+                "END\n");
+    }
+
+    private void dropCompletedReadingFromCaptureInstanceProcedure() throws SQLException {
+        connection.execute("DROP PROCEDURE dbo.DebeziumSQLConnector_CompletedReadingFromCaptureInstance");
+    }
+
+    private List<String> existingChangeTableNames() throws SQLException {
+        return connection
+                .getChangeTables(TestHelper.TEST_DATABASE_1)
+                .stream()
+                .map(ChangeTable::getCaptureInstance)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Squashed commit of the following:

commit 3d3f37b08509b33dda1988172bafbb2fc64cb3bf
Merge: de92a0465 48e250a7a
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Mon Feb 27 23:35:11 2023 +0300

    Merge pull request #141 from ramanenka/CXP-2452-commit-after-ci-deletion

    CXP-2452: Commit the transaction right after a capture instance deletion

commit 48e250a7a4135d8786508ac3cb4d87b97f12f4c3
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Mon Feb 27 18:24:55 2023 +0100

    CXP-2452: Commit the transaction right after a capture instance deletion

commit de92a0465f71ff6392080da85bf2a000516272db
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Fri Jan 13 17:26:19 2023 +0100

    CXP-2369: Execute the stored procedure using metadata connection

commit ce1489e86fc8d9f8bfe0d9107db5b9a3380757a6
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Tue Jan 10 18:05:51 2023 +0100

    CXP-2371: [SPIKE] Test schema change database callbacks against real procedures

commit 30efd8b07d502ee2b763bd085c6caa044f481ad1
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Thu Dec 29 16:49:08 2022 +0100

    CXP-2157: Integration testing of schema change database callbacks

commit 00117322d6aae24da2f8179d81a4824b995b1683
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Thu Dec 29 15:55:03 2022 +0100

    CXP-2184: Use StartReadingFromCaptureInstance

commit a9b7e5f089e9af34ea22a7e07459d5c631dc3f0e
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Mon Aug 29 16:02:05 2022 +0300

    CXP-2153: Track change tables with known stop LSN in a Set instead of a List

commit b8757f39d7d9cd49e1c4b6224abaa43df5fc1b06
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Tue Aug 30 13:19:38 2022 +0300

    CXP-2155: Rework the logic of tracking deletion of capture instances from the server

commit 3b2f029e2268d8825d2bbcd60b358b7f95987544
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Fri Aug 26 18:54:08 2022 +0300

    CXP-2152: Move change tables with known stop LSN out of streaming context

commit 18d81b12c572c50e6d4ce6ed35bd081db9a8ee5a
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Thu Aug 25 19:35:19 2022 +0300

    CXP-2156: Carry over the database.callbacks configuration property from the previous feature branch

commit 1eb25b45726e25f999564f198939292ba29eadcc
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Wed Aug 24 19:28:52 2022 +0300

    CXP-2154: [SPIKE] Refactor determining the source partition of the offset being committed

commit 36ad5451fe99b90ac16cf019b64d9d9ff8581e32
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Wed Aug 24 19:47:45 2022 +0300

    CXP-2154: Enable github actions on database-callbacks branch

commit 76538a4225a8fd0bb65620ea0058b3fa3b52cf18
Author: Vadzim Ramanenka <vramanenka@sugarcrm.com>
Date:   Wed Aug 17 20:53:26 2022 +0300

    CXP-2071: [SPIKE] Refactor schema change handling callbacks to use committed offsets