### PR TITLE
CXP-3424: Use default CDC index for SqlServer Connector 

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -80,7 +80,8 @@ public class SqlServerConnection extends JdbcConnection {
             + LSN_TIMESTAMP_SELECT_STATEMENT;
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION = "FROM [#db].cdc.[fn_cdc_get_all_changes_#table](?, ?, N'all update old')";
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT = "FROM [#db].cdc.[#table]";
-    private static final String GET_ALL_CHANGES_FOR_TABLE_ORDER_BY = "ORDER BY [__$start_lsn] ASC, [__$seqval] ASC, [__$operation] ASC";
+    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION_ORDER_BY = "ORDER BY [__$start_lsn] ASC, [__$seqval] ASC, [__$operation] ASC";
+    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT_ORDER_BY = "ORDER BY [__$start_lsn] ASC, [__$command_id] ASC, [__$seqval] ASC, [__$operation] ASC";
 
     /**
      * Queries the list of captured column names and their change table identifiers in the given database.
@@ -212,7 +213,14 @@ public class SqlServerConnection extends JdbcConnection {
             result += " WHERE " + String.join(" AND ", where) + " ";
         }
 
-        result += GET_ALL_CHANGES_FOR_TABLE_ORDER_BY;
+        switch (dataQueryMode) {
+            case FUNCTION:
+                result += GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION_ORDER_BY;
+                break;
+            case DIRECT:
+                result += GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT_ORDER_BY;
+                break;
+        }
 
         return result;
     }


### PR DESCRIPTION
Adding `__$command_id ASC` to the order clause of the query allows for the usage of the clustered index.